### PR TITLE
Neo4j 5 Syntax Update

### DIFF
--- a/langchain4j-neo4j/src/test/java/dev/langchain4j/store/embedding/neo4j/Neo4jEmbeddingStoreIT.java
+++ b/langchain4j-neo4j/src/test/java/dev/langchain4j/store/embedding/neo4j/Neo4jEmbeddingStoreIT.java
@@ -51,7 +51,7 @@ class Neo4jEmbeddingStoreIT {
     public static final String LABEL_TO_SANITIZE = "Label ` to \\ sanitize";
     
     @Container
-    static Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>(DockerImageName.parse("neo4j:5.14.0"))
+    static Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>(DockerImageName.parse("neo4j:5.26.1"))
             .withAdminPassword(ADMIN_PASSWORD);
 
     private static final String METADATA_KEY = "test-key";


### PR DESCRIPTION
- Upgraded neo4j container to latest 5.x version

- Updated vector index creation syntax
- Updated `SHOW INDEX` syntax

The `indexExists()` still remains, since it throws an error with an existing indexes with the same name but different label/props.
As implemented in langchain-ai [here](https://github.com/langchain-ai/langchain/blob/master/libs/community/langchain_community/vectorstores/neo4j_vector.py#L883)