### PR TITLE
Issue 2543: [FEATURE] LLMGraphTransformer for Knowledge Graph Constru…

### DIFF
--- a/langchain4j-neo4j/pom.xml
+++ b/langchain4j-neo4j/pom.xml
@@ -88,7 +88,7 @@
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-open-ai</artifactId>
             <version>${project.version}</version>
-            <scope>test</scope>
+            <scope>compile</scope>
         </dependency>
 
         <dependency>
@@ -112,12 +112,6 @@
             <groupId>org.tinylog</groupId>
             <artifactId>slf4j-tinylog</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>dev.langchain4j</groupId>
-            <artifactId>langchain4j-open-ai</artifactId>
-            <version>1.0.0-alpha2-SNAPSHOT</version>
-            <scope>compile</scope>
         </dependency>
 
     </dependencies>

--- a/langchain4j-neo4j/pom.xml
+++ b/langchain4j-neo4j/pom.xml
@@ -113,6 +113,12 @@
             <artifactId>slf4j-tinylog</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-open-ai</artifactId>
+            <version>1.0.0-alpha2-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
 
     </dependencies>
 

--- a/langchain4j-neo4j/src/main/java/dev/langchain4j/Neo4jUtils.java
+++ b/langchain4j-neo4j/src/main/java/dev/langchain4j/Neo4jUtils.java
@@ -1,0 +1,4 @@
+package dev.langchain4j;
+
+public class Neo4jUtils {
+}

--- a/langchain4j-neo4j/src/main/java/dev/langchain4j/rag/content/retriever/neo4j/Neo4jContentRetriever.java
+++ b/langchain4j-neo4j/src/main/java/dev/langchain4j/rag/content/retriever/neo4j/Neo4jContentRetriever.java
@@ -61,6 +61,7 @@ public class Neo4jContentRetriever implements ContentRetriever {
         return response.stream().map(Content::from).toList();
     }
 
+    // TODO - riutilizzare questo?
     private String generateCypherQuery(String schema, String question) {
 
         Prompt cypherPrompt = promptTemplate.apply(Map.of("schema", schema, "question", question));

--- a/langchain4j-neo4j/src/main/java/dev/langchain4j/rag/content/retriever/neo4j/Neo4jContentRetriever.java
+++ b/langchain4j-neo4j/src/main/java/dev/langchain4j/rag/content/retriever/neo4j/Neo4jContentRetriever.java
@@ -66,6 +66,11 @@ public class Neo4jContentRetriever implements ContentRetriever {
 
         Prompt cypherPrompt = promptTemplate.apply(Map.of("schema", schema, "question", question));
         String cypherQuery = chatLanguageModel.generate(cypherPrompt.text());
+        return getString(cypherQuery);
+    }
+
+    // TODO - put in Neo4jUtils?
+    public static String getString(String cypherQuery) {
         Matcher matcher = BACKTICKS_PATTERN.matcher(cypherQuery);
         if (matcher.find()) {
             return matcher.group(1);

--- a/langchain4j-neo4j/src/main/java/dev/langchain4j/store/graph/neo4j/Neo4jGraph.java
+++ b/langchain4j-neo4j/src/main/java/dev/langchain4j/store/graph/neo4j/Neo4jGraph.java
@@ -1,5 +1,8 @@
 package dev.langchain4j.store.graph.neo4j;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.transformer.LLMGraphTransformer;
 import lombok.Builder;
 import lombok.Getter;
 import org.neo4j.driver.Driver;
@@ -11,14 +14,23 @@ import org.neo4j.driver.Value;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.summary.ResultSummary;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import static dev.langchain4j.transformer.LLMGraphTransformer.generateMD5;
+import static dev.langchain4j.transformer.LLMGraphTransformer.removeBackticks;
 
+// TODO ... MAYBE USE THIS!!!
 public class Neo4jGraph implements AutoCloseable {
 
+//    private StructuredSchema structuredSchema;
+    
+    private static final String BASE_ENTITY_LABEL = "__Entity__";
+    
     private static final String NODE_PROPERTIES_QUERY = """
             CALL apoc.meta.data()
             YIELD label, other, elementType, type, property
@@ -64,9 +76,13 @@ public class Neo4jGraph implements AutoCloseable {
     }
 
     public ResultSummary executeWrite(String queryString) {
+        return executeWrite(queryString, Map.of());
+    }
+    
+    public ResultSummary executeWrite(String queryString, Map<String, Object> params) {
 
         try (Session session = this.driver.session()) {
-            return session.executeWrite(tx -> tx.run(queryString).consume());
+            return session.executeWrite(tx -> tx.run(queryString, params).consume());
         } catch (ClientException e) {
             throw new Neo4jException("Error executing query: " + queryString, e);
         }
@@ -97,6 +113,129 @@ public class Neo4jGraph implements AutoCloseable {
                 String.join("\n", relationshipProperties) + "\n\n" +
                 "The relationships are the following:\n" +
                 String.join("\n", relationships);
+    }
+    
+    /*
+        TODO - MAYBE THIS
+            self.structured_schema = {
+            "node_props": {el["labels"]: el["properties"] for el in node_properties},
+            "rel_props": {el["type"]: el["properties"] for el in rel_properties},
+            "relationships": relationships,
+            "metadata": {"constraint": constraint, "index": index},
+        }
+     */
+    
+
+    public void addGraphDocuments(List<LLMGraphTransformer.GraphDocument> graphDocuments, boolean includeSource, boolean baseEntityLabel) {
+        if (baseEntityLabel) { // Check if constraint already exists
+//            boolean constraintExists = structuredSchema.getMetadata()
+//                    .getOrDefault("constraint", Collections.emptyList())
+//                    .stream()
+//                    .anyMatch(el -> el.get("labelsOrTypes").equals(Collections.singletonList(BASE_ENTITY_LABEL))
+//                            && el.get("properties").equals(Collections.singletonList("id")));
+
+//            if (!constraintExists) {
+                // Create constraint
+                executeWrite("CREATE CONSTRAINT IF NOT EXISTS FOR (b:" + BASE_ENTITY_LABEL + ") REQUIRE b.id IS UNIQUE;");
+                refreshSchema(); // Refresh constraint information
+//            }
+        }
+
+        String nodeImportQuery = getNodeImportQuery(baseEntityLabel, includeSource);
+        String relImportQuery = getRelImportQuery(baseEntityLabel);
+
+        for (LLMGraphTransformer.GraphDocument document : graphDocuments) {
+            if (!document.getSource().metadata().containsKey("id")) {
+                // TODO - CHECK THIS
+                document.getSource().metadata().put("id", generateMD5(document.getSource().text()));
+            }
+
+            // Remove backticks from node types
+            for (LLMGraphTransformer.Node node : document.getNodes()) {
+                node.setType(removeBackticks(node.getType()));
+            }
+
+            // Import nodes
+            Map<String, Object> nodeParams = new HashMap<>();
+            nodeParams.put("data", document.getNodes().stream()
+                    .map(Neo4jGraph::toMap)
+                    .collect(Collectors.toList()));
+//            nodeParams.put("data", document.getNodes().stream().map(GraphNode::toMap).collect(Collectors.toList()));
+            nodeParams.put("document", document.getSource().metadata().toMap());
+            executeWrite(nodeImportQuery, nodeParams);
+
+            // Import relationships
+            List<Map<String, Object>> relData = document.getRelationships().stream()
+                    .map(rel -> Map.of(
+                            "source", rel.getSourceNode().getId(),
+                            "source_label", removeBackticks(rel.getSourceNode().getType()),
+                            "target", rel.getTargetNode().getId(),
+                            "target_label", removeBackticks(rel.getTargetNode().getType()),
+                            "type", removeBackticks(rel.getType().replace(" ", "_").toUpperCase()),
+                            "properties", Map.of()
+                            // TODO - ADDITIONAL MAYBE "properties", rel.getProperties()
+                    )).toList();
+
+            executeWrite(relImportQuery, Map.of("data", relData));
+        }
+    }
+    
+    
+    private static Map<String, Object> toMap(Object object) {
+        ObjectMapper m = new ObjectMapper();
+        return m.convertValue(object, new TypeReference<>() {});
+    }
+
+    private String getNodeImportQuery(boolean baseEntityLabel, boolean includeSource) {
+        /*
+           TODO 
+               include_docs_query = (
+                "MERGE (d:Document {id:$document.metadata.id}) "
+                "SET d.text = $document.page_content "
+                "SET d += $document.metadata "
+                "WITH d "
+                )
+ 
+         */
+        // String includeDocsQuery = includeSource ? "INCLUDE_DOCS_QUERY" : "";
+        String includeDocsQuery = "";
+        if (baseEntityLabel) {
+            return includeDocsQuery +
+                    "UNWIND $data AS row " +
+                    "MERGE (source:`" + BASE_ENTITY_LABEL + "` {id: row.id}) " +
+                    "SET source += {} " +
+//                    "SET source += row.properties " +
+                    (includeSource ? "MERGE (d)-[:MENTIONS]->(source) " : "") +
+                    "WITH source, row " +
+                    "CALL apoc.create.addLabels(source, [row.type]) YIELD node " +
+                    "RETURN distinct 'done' AS result";
+        } else {
+            return includeDocsQuery +
+                    "UNWIND $data AS row " +
+                    "CALL apoc.merge.node([row.type], {id: row.id}, {}, {}) YIELD node " +
+//                    "CALL apoc.merge.node([row.type], {id: row.id}, row.properties, {}) YIELD node " +
+                    (includeSource ? "MERGE (d)-[:MENTIONS]->(node) " : "") +
+                    "RETURN distinct 'done' AS result";
+        }
+    }
+
+    private String getRelImportQuery(boolean baseEntityLabel) {
+        if (baseEntityLabel) {
+            return "UNWIND $data AS row " +
+                    "MERGE (source:`" + BASE_ENTITY_LABEL + "` {id: row.source}) " +
+                    "MERGE (target:`" + BASE_ENTITY_LABEL + "` {id: row.target}) " +
+                    "WITH source, target, row " +
+                    "CALL apoc.merge.relationship(source, row.type, {}, {}, target) YIELD rel " +
+//                    "CALL apoc.merge.relationship(source, row.type, {}, row.properties, target) YIELD rel " + // TODO - add .properties
+                    "RETURN distinct 'done'";
+        } else {
+            return "UNWIND $data AS row " +
+                    "CALL apoc.merge.node([row.source_label], {id: row.source}, {}, {}) YIELD node as source " +
+                    "CALL apoc.merge.node([row.target_label], {id: row.target}, {}, {}) YIELD node as target " +
+                    "CALL apoc.merge.relationship(source, row.type, {}, {}, target) YIELD rel " +
+//                    "CALL apoc.merge.relationship(source, row.type, {}, {}, target) YIELD rel " + // TODO - add .properties
+                    "RETURN distinct 'done'";
+        }
     }
 
     private List<String> formatNodeProperties(List<Record> records) {

--- a/langchain4j-neo4j/src/main/java/dev/langchain4j/store/graph/neo4j/Neo4jGraph1.java
+++ b/langchain4j-neo4j/src/main/java/dev/langchain4j/store/graph/neo4j/Neo4jGraph1.java
@@ -1,0 +1,274 @@
+//package dev.langchain4j.store.graph.neo4j;
+//
+//import com.fasterxml.jackson.core.type.TypeReference;
+//import com.fasterxml.jackson.databind.ObjectMapper;
+//import dev.langchain4j.transformer.Graph;
+//import dev.langchain4j.transformer.GraphDocument;
+//import lombok.Builder;
+//import lombok.Getter;
+//import org.neo4j.driver.Driver;
+//import org.neo4j.driver.Query;
+//import org.neo4j.driver.Record;
+//import org.neo4j.driver.Result;
+//import org.neo4j.driver.Session;
+//import org.neo4j.driver.Value;
+//import org.neo4j.driver.exceptions.ClientException;
+//import org.neo4j.driver.summary.ResultSummary;
+//
+//import java.util.HashMap;
+//import java.util.List;
+//import java.util.Map;
+//import java.util.stream.Collectors;
+//
+//import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+//import static dev.langchain4j.transformer.LLMGraphTransformer.generateMD5;
+//import static dev.langchain4j.transformer.LLMGraphTransformer.removeBackticks;
+//
+//// TODO ... MAYBE USE THIS!!!
+//public class Neo4jGraph1 implements AutoCloseable {
+//
+////    private StructuredSchema structuredSchema;
+//    
+//    public static final String BASE_ENTITY_LABEL = "__Entity__";
+//    
+//    private static final String NODE_PROPERTIES_QUERY = """
+//            CALL apoc.meta.data()
+//            YIELD label, other, elementType, type, property
+//            WHERE NOT type = "RELATIONSHIP" AND elementType = "node"
+//            WITH label AS nodeLabels, collect({property:property, type:type}) AS properties
+//            RETURN {labels: nodeLabels, properties: properties} AS output
+//            """;
+//
+//    private static final String REL_PROPERTIES_QUERY = """
+//            CALL apoc.meta.data()
+//            YIELD label, other, elementType, type, property
+//            WHERE NOT type = "RELATIONSHIP" AND elementType = "relationship"
+//            WITH label AS nodeLabels, collect({property:property, type:type}) AS properties
+//            RETURN {type: nodeLabels, properties: properties} AS output
+//            """;
+//
+//    private static final String RELATIONSHIPS_QUERY = """
+//            CALL apoc.meta.data()
+//            YIELD label, other, elementType, type, property
+//            WHERE type = "RELATIONSHIP" AND elementType = "node"
+//            UNWIND other AS other_node
+//            RETURN {start: label, type: property, end: toString(other_node)} AS output
+//            """;
+//
+//    private final Driver driver;
+//
+//    @Getter
+//    private String schema;
+//
+//    @Builder
+//    public Neo4jGraph1(final Driver driver) {
+//
+//        this.driver = ensureNotNull(driver, "driver");
+//        this.driver.verifyConnectivity();
+//        try {
+//            refreshSchema();
+//        } catch (ClientException e) {
+//            if ("Neo.ClientError.Procedure.ProcedureNotFound".equals(e.code())) {
+//                throw new Neo4jException("Please ensure the APOC plugin is installed in Neo4j", e);
+//            }
+//            throw e;
+//        }
+//    }
+//
+//    public ResultSummary executeWrite(String queryString) {
+//        return executeWrite(queryString, Map.of());
+//    }
+//    
+//    public ResultSummary executeWrite(String queryString, Map<String, Object> params) {
+//
+//        try (Session session = this.driver.session()) {
+//            return session.executeWrite(tx -> tx.run(queryString, params).consume());
+//        } catch (ClientException e) {
+//            throw new Neo4jException("Error executing query: " + queryString, e);
+//        }
+//    }
+//
+//    public List<Record> executeRead(String queryString) {
+//
+//        try (Session session = this.driver.session()) {
+//            return session.executeRead(tx -> {
+//                Query query = new Query(queryString);
+//                Result result = tx.run(query);
+//                return result.list();
+//            });
+//        } catch (ClientException e) {
+//            throw new Neo4jException("Error executing query: " + queryString, e);
+//        }
+//    }
+//
+//    public void refreshSchema() {
+//
+//        List<String> nodeProperties = formatNodeProperties(executeRead(NODE_PROPERTIES_QUERY));
+//        List<String> relationshipProperties = formatRelationshipProperties(executeRead(REL_PROPERTIES_QUERY));
+//        List<String> relationships = formatRelationships(executeRead(RELATIONSHIPS_QUERY));
+//
+//        this.schema = "Node properties are the following:\n" +
+//                String.join("\n", nodeProperties) + "\n\n" +
+//                "Relationship properties are the following:\n" +
+//                String.join("\n", relationshipProperties) + "\n\n" +
+//                "The relationships are the following:\n" +
+//                String.join("\n", relationships);
+//    }
+//    
+//    /*
+//        TODO - MAYBE THIS
+//            self.structured_schema = {
+//            "node_props": {el["labels"]: el["properties"] for el in node_properties},
+//            "rel_props": {el["type"]: el["properties"] for el in rel_properties},
+//            "relationships": relationships,
+//            "metadata": {"constraint": constraint, "index": index},
+//        }
+//     */
+//    
+//
+//    public void addGraphDocuments(List<GraphDocument> graphDocuments, boolean includeSource, boolean baseEntityLabel) {
+//        if (baseEntityLabel) { // Check 
+//            // Create constraint if not exists
+//            executeWrite("CREATE CONSTRAINT IF NOT EXISTS FOR (b:" + BASE_ENTITY_LABEL + ") REQUIRE b.id IS UNIQUE;");
+//            refreshSchema(); // Refresh constraint information
+//        }
+//
+//        String nodeImportQuery = getNodeImportQuery(baseEntityLabel, includeSource);
+//        String relImportQuery = getRelImportQuery(baseEntityLabel);
+//
+//        for (GraphDocument document : graphDocuments) {
+//            if (!document.getSource().metadata().containsKey("id")) {
+//                // TODO - CHECK THIS
+//                document.getSource().metadata().put("id", generateMD5(document.getSource().text()));
+//            }
+//
+//            // Remove backticks from node types
+//            for (GraphDocument.Node node : document.getNodes()) {
+//                node.setType(removeBackticks(node.getType()));
+//            }
+//
+//            // Import nodes
+//            Map<String, Object> nodeParams = new HashMap<>();
+//            nodeParams.put("data", document.getNodes().stream()
+//                    .map(Neo4jGraph1::toMap)
+//                    .collect(Collectors.toList()));
+////            nodeParams.put("data", document.getNodes().stream().map(GraphNode::toMap).collect(Collectors.toList()));
+//            nodeParams.put("document", document.getSource().metadata().toMap());
+//            executeWrite(nodeImportQuery, nodeParams);
+//
+//            // Import relationships
+//            List<Map<String, Object>> relData = document.getRelationships().stream()
+//                    .map(rel -> Map.of(
+//                            "source", rel.getSourceNode().getId(),
+//                            "source_label", removeBackticks(rel.getSourceNode().getType()),
+//                            "target", rel.getTargetNode().getId(),
+//                            "target_label", removeBackticks(rel.getTargetNode().getType()),
+//                            "type", removeBackticks(rel.getType().replace(" ", "_").toUpperCase()),
+//                            "properties", Map.of()
+//                            // TODO - ADDITIONAL MAYBE "properties", rel.getProperties()
+//                    )).toList();
+//
+//            executeWrite(relImportQuery, Map.of("data", relData));
+//        }
+//    }
+//    
+//    // todo - util class???
+//    private static Map<String, Object> toMap(Object object) {
+//        ObjectMapper m = new ObjectMapper();
+//        return m.convertValue(object, new TypeReference<>() {});
+//    }
+//
+//    private String getNodeImportQuery(boolean baseEntityLabel, boolean includeSource) {
+//        /*
+//           TODO 
+//               include_docs_query = (
+//                "MERGE (d:Document {id:$document.metadata.id}) "
+//                "SET d.text = $document.page_content "
+//                "SET d += $document.metadata "
+//                "WITH d "
+//                )
+// 
+//         */
+//        // String includeDocsQuery = includeSource ? "INCLUDE_DOCS_QUERY" : "";
+//        String includeDocsQuery = "";
+//        if (baseEntityLabel) {
+//            return includeDocsQuery +
+//                    "UNWIND $data AS row " +
+//                    "MERGE (source:`" + BASE_ENTITY_LABEL + "` {id: row.id}) " +
+//                    "SET source += {} " +
+////                    "SET source += row.properties " +
+//                    (includeSource ? "MERGE (d)-[:MENTIONS]->(source) " : "") +
+//                    "WITH source, row " +
+//                    "CALL apoc.create.addLabels(source, [row.type]) YIELD node " +
+//                    "RETURN distinct 'done' AS result";
+//        } else {
+//            return includeDocsQuery +
+//                    "UNWIND $data AS row " +
+//                    "CALL apoc.merge.node([row.type], {id: row.id}, {}, {}) YIELD node " +
+////                    "CALL apoc.merge.node([row.type], {id: row.id}, row.properties, {}) YIELD node " +
+//                    (includeSource ? "MERGE (d)-[:MENTIONS]->(node) " : "") +
+//                    "RETURN distinct 'done' AS result";
+//        }
+//    }
+//
+//    private String getRelImportQuery(boolean baseEntityLabel) {
+//        if (baseEntityLabel) {
+//            return "UNWIND $data AS row " +
+//                    "MERGE (source:`" + BASE_ENTITY_LABEL + "` {id: row.source}) " +
+//                    "MERGE (target:`" + BASE_ENTITY_LABEL + "` {id: row.target}) " +
+//                    "WITH source, target, row " +
+//                    "CALL apoc.merge.relationship(source, row.type, {}, {}, target) YIELD rel " +
+////                    "CALL apoc.merge.relationship(source, row.type, {}, row.properties, target) YIELD rel " + // TODO - add .properties
+//                    "RETURN distinct 'done'";
+//        } else {
+//            return "UNWIND $data AS row " +
+//                    "CALL apoc.merge.node([row.source_label], {id: row.source}, {}, {}) YIELD node as source " +
+//                    "CALL apoc.merge.node([row.target_label], {id: row.target}, {}, {}) YIELD node as target " +
+//                    "CALL apoc.merge.relationship(source, row.type, {}, {}, target) YIELD rel " +
+////                    "CALL apoc.merge.relationship(source, row.type, {}, {}, target) YIELD rel " + // TODO - add .properties
+//                    "RETURN distinct 'done'";
+//        }
+//    }
+//
+//    private List<String> formatNodeProperties(List<Record> records) {
+//
+//        return records.stream()
+//                .map(this::getOutput)
+//                .map(r -> String.format("%s %s", r.asMap().get("labels"), formatMap(r.get("properties").asList(Value::asMap))))
+//                .toList();
+//    }
+//
+//    private List<String> formatRelationshipProperties(List<Record> records) {
+//
+//        return records.stream()
+//                .map(this::getOutput)
+//                .map(r -> String.format("%s %s", r.get("type"), formatMap(r.get("properties").asList(Value::asMap))))
+//                .toList();
+//    }
+//
+//    private List<String> formatRelationships(List<Record> records) {
+//
+//        return records.stream()
+//                .map(r -> getOutput(r).asMap())
+//                .map(r -> String.format("(:%s)-[:%s]->(:%s)", r.get("start"), r.get("type"), r.get("end")))
+//                .toList();
+//    }
+//
+//    private Value getOutput(Record record) {
+//
+//        return record.get("output");
+//    }
+//
+//    private String formatMap(List<Map<String, Object>> properties) {
+//
+//        return properties.stream()
+//                .map(prop -> prop.get("property") + ":" + prop.get("type"))
+//                .collect(Collectors.joining(", ", "{", "}"));
+//    }
+//
+//    @Override
+//    public void close() {
+//
+//        this.driver.close();
+//    }
+//}

--- a/langchain4j-neo4j/src/main/java/dev/langchain4j/store/graph/neo4j/StructuredSchema.java
+++ b/langchain4j-neo4j/src/main/java/dev/langchain4j/store/graph/neo4j/StructuredSchema.java
@@ -1,0 +1,8 @@
+//package dev.langchain4j.store.graph.neo4j;
+//
+//import java.util.List;
+//
+//public class StructuredSchema {
+//    private List<String> nodeProperties;
+//    private List<String> relProperties
+//}

--- a/langchain4j-neo4j/src/main/java/dev/langchain4j/transformer/Graph.java
+++ b/langchain4j-neo4j/src/main/java/dev/langchain4j/transformer/Graph.java
@@ -1,0 +1,21 @@
+package dev.langchain4j.transformer;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.List;
+
+public class Graph {
+//    private List<Node> nodes;
+//    private List<Edge> edges;
+//
+//    public Graph() {
+//        this.nodes = new java.util.ArrayList<>();
+//        this.edges = new java.util.ArrayList<>();
+//    }
+
+
+}

--- a/langchain4j-neo4j/src/main/java/dev/langchain4j/transformer/GraphDocument.java
+++ b/langchain4j-neo4j/src/main/java/dev/langchain4j/transformer/GraphDocument.java
@@ -1,0 +1,69 @@
+package dev.langchain4j.transformer;
+
+import dev.langchain4j.data.document.Document;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.Set;
+
+@Getter
+public class GraphDocument {
+    private Set<Node> nodes;
+    private Set<Edge> relationships;
+    private Document source;
+
+    public GraphDocument(Set<GraphDocument.Node> nodes, Set<GraphDocument.Edge> relationships, Document source) {
+        this.nodes = nodes;
+        this.relationships = relationships;
+        this.source = source;
+    }
+
+//    public Document getSource() {
+//        return source;
+//    }
+//
+//    public Set<GraphDocument.Node> getNodes() {
+//        return nodes;
+//    }
+//
+//    public Set<GraphDocument.Edge> getRelationships() {
+//        return relationships;
+//    }
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode // TODO - WRITE that is to de-duplicate nodes, e.g. testAddGraphDocumentsWithDeDuplication
+    // @JsonSerialize
+    @ToString // for testing purpose
+    public static class Node {
+        private String id;
+        //        private String data;
+        private String type;
+
+        public Node(String id, String type) {
+            this.id = id;
+            this.type = type;
+        }
+    }
+
+    @Getter
+    @EqualsAndHashCode
+    // @JsonSerialize
+    @ToString // for testing purpose
+    public static class Edge {
+        //        private String from;
+//        private String to;
+        private Node sourceNode;
+        private Node targetNode;
+        private String type;
+
+        public Edge(final Node sourceNode, final Node targetNode, final String type) {
+            this.sourceNode = sourceNode;
+            this.targetNode = targetNode;
+            this.type = type;
+        }
+
+    }
+}

--- a/langchain4j-neo4j/src/main/java/dev/langchain4j/transformer/LLMGraphTransformer.java
+++ b/langchain4j-neo4j/src/main/java/dev/langchain4j/transformer/LLMGraphTransformer.java
@@ -1,0 +1,458 @@
+package dev.langchain4j.transformer;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.input.Prompt;
+import dev.langchain4j.model.input.PromptTemplate;
+import dev.langchain4j.model.openai.OpenAiChatModel;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+// TODO --- vedere la parte # Strict mode filtering in python
+
+/* TODO
+    The baseEntityLabel parameter assigns an additional __Entity__ label to each node, 
+    enhancing indexing and query performance.
+    The include_source parameter links nodes to their originating documents, 
+    facilitating data traceability and context understanding.
+ */
+
+/* TODO 
+    # Extract graph data
+    graph_documents = llm_transformer.convert_to_graph_documents(documents)
+    # Store to neo4j
+    graph.add_graph_documents(
+      graph_documents, 
+      baseEntityLabel=True, 
+      include_source=True
+    )
+ */
+
+public class LLMGraphTransformer {
+
+    public static class Graph {
+        private List<Node> nodes;
+        private List<Edge> edges;
+
+        public Graph() {
+            this.nodes = new java.util.ArrayList<>();
+            this.edges = new java.util.ArrayList<>();
+        }
+
+        public void addNode(Node node) {
+            nodes.add(node);
+        }
+
+        public void addEdge(Edge edge) {
+            edges.add(edge);
+        }
+
+        public List<Node> getNodes() {
+            return nodes;
+        }
+
+        public List<Edge> getEdges() {
+            return edges;
+        }
+
+        public boolean constraintExists(String label, String property) {
+            return false; // Placeholder for actual implementation
+        }
+
+        public void createConstraint(String label, String property) {
+            // Placeholder for actual implementation
+        }
+    }
+
+    
+    public static class Node {
+        private String id;
+//        private String data;
+        private String type;
+
+        public Node(String id, String type) {
+            this.id = id;
+            this.type = type;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+//        public String getData() {
+//            return data;
+//        }
+
+        public String getType() {
+            return type;
+        }
+
+        public void setType(String type) {
+            this.type = type;
+        }
+    }
+
+    public static class Edge {
+//        private String from;
+//        private String to;
+        private Node sourceNode;
+        private Node targetNode;
+        private String type;
+
+        public Edge(final Node sourceNode, final Node targetNode, final String type) {
+            this.sourceNode = sourceNode;
+            this.targetNode = targetNode;
+            this.type = type;
+        }
+
+        public Node getSourceNode() {
+            return sourceNode;
+        }
+
+        public Node getTargetNode() {
+            return targetNode;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        //        public Edge(Node sourceNode, Node targetNode, String type) {
+//            this.from = from;
+//            this.to = to;
+//        }
+//
+//        public String getSourceLabel() {
+//            return sourceLabel;
+//        }
+//
+//        public String getTargetLabel() {
+//            return targetLabel;
+//        }
+//
+//        public String getType() {
+//            return type;
+//        }
+//
+//        public String getFrom() {
+//            return from;
+//        }
+//
+//        public String getTo() {
+//            return to;
+//        }
+//
+//        public void setSourceLabel(String sourceLabel) {
+//            this.sourceLabel = sourceLabel;
+//        }
+//
+//        public void setTargetLabel(String targetLabel) {
+//            this.targetLabel = targetLabel;
+//        }
+//
+//        public void setType(String type) {
+//            this.type = type;
+//        }
+    }
+
+    // TODO - WHAT???
+    interface LLMService {
+        String callLLM(String prompt);
+    }
+
+    // TODO - substitute to Document of Langchain4j
+//    static class Document {
+//        private String id;
+//        private String content;
+//
+//        public Document(String id, String content) {
+//            this.id = id;
+//            this.content = content;
+//        }
+//
+//        public String getId() {
+//            return id;
+//        }
+//
+//        public String getContent() {
+//            return content;
+//        }
+//    }
+
+    public static class GraphDocument {
+//        private String id;
+//        private String content;
+        private Set<Node> nodes;
+        private Set<Edge> relationships;
+        private Document source;
+
+        public GraphDocument(Set<Node> nodes, Set<Edge> relationships, Document source) {
+            this.nodes = nodes;
+            this.relationships = relationships;
+            this.source = source;
+        }
+
+//        public String getId() {
+//            return id;
+//        }
+//
+//        public String getContent() {
+//            return content;
+//        }
+//
+//        public void setId(String id) {
+//            this.id = id;
+//        }
+
+
+        public Document getSource() {
+            return source;
+        }
+
+        public Set<Node> getNodes() {
+            return nodes;
+        }
+
+        public Set<Edge> getRelationships() {
+            return relationships;
+        }
+    }
+
+
+    // TODO - SPLIT CLASSES
+    
+    private final LLMService llmService;
+
+    // TODO - use @Builder
+    public LLMGraphTransformer(LLMService llmService) {
+        this.llmService = llmService;
+    }
+
+//    public Graph transform(Graph graph) {
+//        Graph transformedGraph = new Graph();
+//
+//        for (Node node : graph.getNodes()) {
+//            Node transformedNode = transformNode(node);
+//            transformedGraph.addNode(transformedNode);
+//        }
+//
+//        for (Edge edge : graph.getEdges()) {
+//            transformedGraph.addEdge(edge);
+//        }
+//
+//        return transformedGraph;
+//    }
+//
+//    private Node transformNode(Node node) {
+//        String prompt = "Transform this node: " + node.getData();
+//        String transformedData = llmService.callLLM(prompt);
+//        return new Node(node.getId(), transformedData);
+//    }
+
+    public List<GraphDocument> convertToGraphDocuments(List<Document> documents) {
+        // TODO - MAGARI METTERE ANCHE UN FILTER IS NOT NULL
+        return documents.stream().map(this::processResponse).collect(Collectors.toList());
+    }
+
+    public List<ChatMessage> createUnstructuredPrompt(String text, List<String> nodeLabels, List<String> relTypes, String relationshipType, String additionalInstructions) {
+        String nodeLabelsStr = nodeLabels != null ? nodeLabels.toString() : "";
+        String relTypesStr = "";
+        if (relTypes != null) {
+            if ("tuple".equals(relationshipType)) {
+                Set<String> uniqueRelTypes = new HashSet<>();
+                for (String rel : relTypes) {
+                    uniqueRelTypes.add(rel);
+                }
+                relTypesStr = uniqueRelTypes.toString();
+            } else {
+                relTypesStr = relTypes.toString();
+            }
+        }
+
+        String systemPrompt = String.join("\n", Arrays.asList(
+                "You are a top-tier algorithm designed for extracting information in structured formats to build a knowledge graph.",
+                "Your task is to identify entities and relations from a given text and generate output in JSON format.",
+                "Each object should have keys: 'head', 'head_type', 'relation', 'tail', and 'tail_type'.",
+                nodeLabels != null ? "The 'head_type' and 'tail_type' must be one of: " + nodeLabelsStr : "",
+                relTypes != null ? "The 'relation' must be one of: " + relTypesStr : "",
+                "IMPORTANT NOTES:\n- Don't add any explanation or extra text.",
+                additionalInstructions
+        ));
+
+        final SystemMessage systemMessage = new SystemMessage(systemPrompt);
+
+        String humanPrompt = String.join("\n", Arrays.asList(
+                "Based on the following example, extract entities and relations from the provided text.",
+                nodeLabels != null ? "# ENTITY TYPES:\n" + nodeLabelsStr : "",
+                relTypes != null ? "# RELATION TYPES:\n" + relTypesStr : "",
+                "For the following text, extract entities and relations as in the provided example.",
+                "Text: " + text
+        ));
+
+        final UserMessage userMessage = new UserMessage(humanPrompt);
+
+        return List.of(systemMessage, userMessage);
+    }
+
+    private GraphDocument processResponse(Document document) {
+//        String text = document.getContent();
+        
+        /*
+        
+            TODO 
+           prompt = prompt or create_unstructured_prompt(
+                allowed_nodes,
+                allowed_relationships,
+                self._relationship_type,
+                additional_instructions,
+            )
+            
+            rawSchema = self.chain.invoke({"input": text}, config=config)
+         */
+        
+        // TODO - configurable chatLanguageModel
+        ChatLanguageModel chatModel = OpenAiChatModel.builder()
+                .baseUrl("demo")
+                .apiKey("demo")
+                .organizationId(System.getenv("OPENAI_ORGANIZATION_ID"))
+                .modelName("gpt-4o-mini")
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+        final String text = document.text();
+        
+        
+        // todo - configurable, pr 
+        //  use PromptTemplate handling via {{ }}
+        final List<ChatMessage> messages = createUnstructuredPrompt(text, null, null, null, "");
+        // final PromptTemplate template = PromptTemplate.from(prompt);
+
+        System.out.println("messages = " + messages);
+        // TODO -- PromptTemplate
+
+        //final Prompt apply = template.apply(Map.of());
+        //final String text1 = apply.text();
+        String rawSchema = chatModel.generate(messages).content().text();
+                // new MockLLMService().callLLM(text);
+
+        Set<Node> nodesSet = new HashSet<>();
+        Set<Edge> relationships = new HashSet<>();
+
+        List<Map<String, String>> parsedJson = parseJson(rawSchema);
+        if (parsedJson == null) {
+            // TODO - EVALUATE A RETRY MECHANISM CONFIGURABLE
+            System.out.println("parsedJson = " + parsedJson);
+            return new GraphDocument(Set.of(), Set.of(), document);
+        }
+
+        for (Map<String, String> rel : parsedJson) {
+            if (!rel.containsKey("head") || !rel.containsKey("tail") || !rel.containsKey("relation")) {
+                continue;
+            }
+
+            Node sourceNode = new Node(rel.get("head"), rel.getOrDefault("head_type", "DefaultNodeType"));
+            Node targetNode = new Node(rel.get("tail"), rel.getOrDefault("tail_type", "DefaultNodeType"));
+
+            nodesSet.add(sourceNode);
+            nodesSet.add(targetNode);
+
+            final String relation = rel.get("relation");
+            final Edge edge = new Edge(sourceNode, targetNode, relation);
+            relationships.add(edge);
+//            relationships.add(new Edge(sourceNode.getId(), targetNode.getId(), rel.get("relation")));
+        }
+
+//        List<Node> nodes = new ArrayList<>(nodesSet);
+        // TODO - REMOVE THE TOSTRING()
+        return new GraphDocument(nodesSet, relationships, document);
+//        return new GraphDocument(nodes, relationships, document);
+    }
+
+    private List<Map<String, String>> parseJson(String jsonString) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        // TODO - COMMENT THIS, can output json``` sometimes
+        jsonString = jsonString.replaceAll("```", "")
+                .replaceAll("json", "");
+        try {
+            return objectMapper.readValue(jsonString, new TypeReference<List<Map<String, String>>>() {});
+        } catch (Exception e) {
+            System.out.println("e = " + e);
+            return null;
+            // throw new RuntimeException("Error parsing JSON", e);
+        }
+        // Placeholder for actual JSON parsing
+    }
+    
+//    public List<GraphDocument> convertToGraphDocuments(List<Document> documents) {
+//        return documents.stream()
+//                .map(doc -> new GraphDocument(doc.getId(), doc.getContent()))
+//                .collect(Collectors.toList());
+//    }
+
+    // TODO - QUESTO IN REALTA DOVREBBE VERAMENTE GENERARE ENTITÀ
+    //  QUINDI VA IN UNA CLASSE SEPARATA IN TEORIA...
+    // TODO - METTERE UPPERCASE PER LE RELAZIONI, PERCHE PUO CAPITARE is_on INVECE DI IS_ON
+    //      CAPITALIZE LABEL???
+    public void addGraphDocuments(Graph graph, List<GraphDocument> graphDocuments, boolean includeSource, boolean baseEntityLabel) {
+        if (baseEntityLabel && !graph.constraintExists("BaseEntity", "id")) {
+            graph.createConstraint("BaseEntity", "id");
+        }
+
+            // TODO - STA ROBA VA IN NEO4J
+//        for (GraphDocument doc : graphDocuments) {
+//            if (doc.getId() == null || doc.getId().isEmpty()) {
+//                doc.setId(generateMD5(doc.getContent()));
+//            }
+//
+//            for (Node node : doc.getNodes()) {
+//                node.setType(removeBackticks(node.getType()));
+//                graph.addNode(node);
+//            }
+//
+//            for (Edge edge : doc.getRelationships()) {
+//                edge.setSourceLabel(removeBackticks(edge.getSourceLabel()));
+//                edge.setTargetLabel(removeBackticks(edge.getTargetLabel()));
+//                edge.setType(removeBackticks(edge.getType().replace(" ", "_").toUpperCase()));
+//                graph.addEdge(edge);
+//            }
+//        }
+    }
+
+    public static String generateMD5(String input) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("MD5");
+            md.update(input.getBytes());
+            byte[] digest = md.digest();
+            StringBuilder sb = new StringBuilder();
+            for (byte b : digest) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("MD5 algorithm not found", e);
+        }
+    }
+
+    public static String removeBackticks(String input) {
+        return input.replace("`", "");
+    }
+}

--- a/langchain4j-neo4j/src/main/java/dev/langchain4j/transformer/LLMGraphTransformer.java
+++ b/langchain4j-neo4j/src/main/java/dev/langchain4j/transformer/LLMGraphTransformer.java
@@ -198,7 +198,9 @@ public class LLMGraphTransformer {
         
         // TODO - DEPRECATED
         List<Map<String, String>> parsedJson = getJsonResult(messages);
-        if (parsedJson == null) return null;
+        if (parsedJson == null || parsedJson.isEmpty()) {
+            return null;
+        }
 
         for (Map<String, String> rel : parsedJson) {
             if (!rel.containsKey("head") || !rel.containsKey("tail") || !rel.containsKey("relation")) {
@@ -214,6 +216,10 @@ public class LLMGraphTransformer {
             final String relation = rel.get("relation");
             final Edge edge = new Edge(sourceNode, targetNode, relation);
             relationships.add(edge);
+        }
+        
+        if (nodesSet.isEmpty()) {
+            return null;
         }
 
         return new GraphDocument(nodesSet, relationships, document);

--- a/langchain4j-neo4j/src/main/java/dev/langchain4j/transformer/LLMGraphTransformer.java
+++ b/langchain4j-neo4j/src/main/java/dev/langchain4j/transformer/LLMGraphTransformer.java
@@ -1,308 +1,163 @@
 package dev.langchain4j.transformer;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import dev.langchain4j.data.document.Document;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.chat.ChatLanguageModel;
-import dev.langchain4j.model.input.Prompt;
-import dev.langchain4j.model.input.PromptTemplate;
-import dev.langchain4j.model.openai.OpenAiChatModel;
+import lombok.Builder;
+import lombok.Getter;
 
-import java.util.ArrayList;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
+import static dev.langchain4j.transformer.GraphDocument.*;
+import dev.langchain4j.internal.RetryUtils;
 
-// TODO --- vedere la parte # Strict mode filtering in python
-
-/* TODO
-    The baseEntityLabel parameter assigns an additional __Entity__ label to each node, 
-    enhancing indexing and query performance.
-    The include_source parameter links nodes to their originating documents, 
-    facilitating data traceability and context understanding.
+/**
+ * TODO - vedere se lo fa da solo,
+ * fare un document con Keanu Reeves e K. Reeves
+ * se non lo fa, aggiustare il prompt magari? O forse tra le options?
+ * https://chatgpt.com/c/67b8568b-db80-800c-8aab-b4c3f1fb434f
+ * 
  */
 
-/* TODO 
-    # Extract graph data
-    graph_documents = llm_transformer.convert_to_graph_documents(documents)
-    # Store to neo4j
-    graph.add_graph_documents(
-      graph_documents, 
-      baseEntityLabel=True, 
-      include_source=True
-    )
- */
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import static dev.langchain4j.transformer.LLMGraphTransformerUtils.*;
 
+
+@Getter
 public class LLMGraphTransformer {
 
-    public static class Graph {
-        private List<Node> nodes;
-        private List<Edge> edges;
 
-        public Graph() {
-            this.nodes = new java.util.ArrayList<>();
-            this.edges = new java.util.ArrayList<>();
-        }
-
-        public void addNode(Node node) {
-            nodes.add(node);
-        }
-
-        public void addEdge(Edge edge) {
-            edges.add(edge);
-        }
-
-        public List<Node> getNodes() {
-            return nodes;
-        }
-
-        public List<Edge> getEdges() {
-            return edges;
-        }
-
-        public boolean constraintExists(String label, String property) {
-            return false; // Placeholder for actual implementation
-        }
-
-        public void createConstraint(String label, String property) {
-            // Placeholder for actual implementation
-        }
-    }
-
+    /*
+    TODO - RICOPIARE QUESTO COMMENTO
     
-    public static class Node {
-        private String id;
-//        private String data;
-        private String type;
 
-        public Node(String id, String type) {
-            this.id = id;
-            this.type = type;
-        }
+     */
 
-        public String getId() {
-            return id;
-        }
+    /*
 
-//        public String getData() {
-//            return data;
-//        }
-
-        public String getType() {
-            return type;
-        }
-
-        public void setType(String type) {
-            this.type = type;
-        }
-    }
-
-    public static class Edge {
-//        private String from;
-//        private String to;
-        private Node sourceNode;
-        private Node targetNode;
-        private String type;
-
-        public Edge(final Node sourceNode, final Node targetNode, final String type) {
-            this.sourceNode = sourceNode;
-            this.targetNode = targetNode;
-            this.type = type;
-        }
-
-        public Node getSourceNode() {
-            return sourceNode;
-        }
-
-        public Node getTargetNode() {
-            return targetNode;
-        }
-
-        public String getType() {
-            return type;
-        }
-
-        //        public Edge(Node sourceNode, Node targetNode, String type) {
-//            this.from = from;
-//            this.to = to;
-//        }
-//
-//        public String getSourceLabel() {
-//            return sourceLabel;
-//        }
-//
-//        public String getTargetLabel() {
-//            return targetLabel;
-//        }
-//
-//        public String getType() {
-//            return type;
-//        }
-//
-//        public String getFrom() {
-//            return from;
-//        }
-//
-//        public String getTo() {
-//            return to;
-//        }
-//
-//        public void setSourceLabel(String sourceLabel) {
-//            this.sourceLabel = sourceLabel;
-//        }
-//
-//        public void setTargetLabel(String targetLabel) {
-//            this.targetLabel = targetLabel;
-//        }
-//
-//        public void setType(String type) {
-//            this.type = type;
-//        }
-    }
-
-    // TODO - WHAT???
-    interface LLMService {
-        String callLLM(String prompt);
-    }
-
-    // TODO - substitute to Document of Langchain4j
-//    static class Document {
-//        private String id;
-//        private String content;
-//
-//        public Document(String id, String content) {
-//            this.id = id;
-//            this.content = content;
-//        }
-//
-//        public String getId() {
-//            return id;
-//        }
-//
-//        public String getContent() {
-//            return content;
-//        }
-//    }
-
-    public static class GraphDocument {
-//        private String id;
-//        private String content;
-        private Set<Node> nodes;
-        private Set<Edge> relationships;
-        private Document source;
-
-        public GraphDocument(Set<Node> nodes, Set<Edge> relationships, Document source) {
-            this.nodes = nodes;
-            this.relationships = relationships;
-            this.source = source;
-        }
-
-//        public String getId() {
-//            return id;
-//        }
-//
-//        public String getContent() {
-//            return content;
-//        }
-//
-//        public void setId(String id) {
-//            this.id = id;
-//        }
-
-
-        public Document getSource() {
-            return source;
-        }
-
-        public Set<Node> getNodes() {
-            return nodes;
-        }
-
-        public Set<Edge> getRelationships() {
-            return relationships;
-        }
-    }
-
-
-    // TODO - SPLIT CLASSES
+    TODO Option to link entities back to the source document
     
-    private final LLMService llmService;
+    TODO Additional metadata about the entities and their relationships (e.g. facts, claims, confidence-scores)
+    TODO - JUST A FACT These knowledge graphs form the foundation for advanced RAG patterns in GraphRAG (see https://graphrag.com)
+    TODO- JUST A FACT, WRITE ON THE PR Besides data from document loaders also data that already exists in large text fields in databases (semi-structured data) could be analyzed and extracted
+    This also offers the means to then run additional algorithms on the data e.g. for query focused summarization that compute communities/clusters of topics and summarize them with an LLM
+     */
 
-    // TODO - use @Builder
-    public LLMGraphTransformer(LLMService llmService) {
-        this.llmService = llmService;
+    private final List<String> allowedNodes;
+    private final List<String> allowedRelationships;
+    private final List<ChatMessage> prompt;
+    private final boolean strictMode;
+    private final boolean ignoreToolUsage;
+    private final String additionalInstructions;
+    private final ChatLanguageModel model;
+    private final List<Map<String, String>> examples;
+    private final Integer maxAttempts;
+    
+    /**
+     * It allows specifying constraints on the types of nodes and relationships to include in the output graph.
+     * The class supports extracting properties for both nodes and relationships.
+     * 
+     * Example: TODO
+     * 
+     * @param model the {@link ChatLanguageModel} (required)
+     * @param allowedNodes Specifies which node types are allowed in the graph. If null or empty allows all node types (default: [])
+     * @param allowedRelationships Specifies which relationship types are allowed in the graph. If null or empty allows all relationship types (default: [])
+     * @param prompt TODO
+     * @param strictMode TODO
+     * @param ignoreToolUsage TODO
+     * @param additionalInstructions Allows you to add additional instructions to the prompt without having to change the whole prompt (default: '')
+     * @param examples Allows you to add additional instructions to the prompt without having to change the whole prompt (default: {@link LLMGraphTransformerUtils#EXAMPLES_PROMPT})
+     * @param maxAttempts Retry N times the transformation if it fails (default: 1)
+     */
+    @Builder
+    public LLMGraphTransformer(ChatLanguageModel model,
+                               List<String> allowedNodes,
+                               List<String> allowedRelationships,
+                               List<ChatMessage> prompt,
+                               Boolean strictMode,
+                               Boolean ignoreToolUsage,
+                               String additionalInstructions,
+                               List<Map<String, String>> examples,
+                               Integer maxAttempts) {
+
+        this.model = ensureNotNull(model, "model");
+        
+        this.allowedNodes = getOrDefault(allowedNodes, List.of());
+        this.allowedRelationships = getOrDefault(allowedRelationships, List.of());
+        this.prompt = prompt;
+        
+        this.maxAttempts = getOrDefault(maxAttempts, 1);
+        // TODO ??
+        this.strictMode = getOrDefault(strictMode, true);
+//        this.nodeProperties = nodeProperties;
+//        this.relationshipProperties = relationshipProperties;
+
+        // TODO ??
+        this.ignoreToolUsage = getOrDefault(ignoreToolUsage, false);
+        this.additionalInstructions = getOrDefault(additionalInstructions, "");
+        
+        this.examples = getOrDefault(examples, EXAMPLES_PROMPT);
+        
     }
-
-//    public Graph transform(Graph graph) {
-//        Graph transformedGraph = new Graph();
-//
-//        for (Node node : graph.getNodes()) {
-//            Node transformedNode = transformNode(node);
-//            transformedGraph.addNode(transformedNode);
-//        }
-//
-//        for (Edge edge : graph.getEdges()) {
-//            transformedGraph.addEdge(edge);
-//        }
-//
-//        return transformedGraph;
-//    }
-//
-//    private Node transformNode(Node node) {
-//        String prompt = "Transform this node: " + node.getData();
-//        String transformedData = llmService.callLLM(prompt);
-//        return new Node(node.getId(), transformedData);
-//    }
+    
 
     public List<GraphDocument> convertToGraphDocuments(List<Document> documents) {
-        // TODO - MAGARI METTERE ANCHE UN FILTER IS NOT NULL
-        return documents.stream().map(this::processResponse).collect(Collectors.toList());
+        return documents.stream().map(this::processResponse)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
-    public List<ChatMessage> createUnstructuredPrompt(String text, List<String> nodeLabels, List<String> relTypes, String relationshipType, String additionalInstructions) {
-        String nodeLabelsStr = nodeLabels != null ? nodeLabels.toString() : "";
-        String relTypesStr = "";
-        if (relTypes != null) {
-            if ("tuple".equals(relationshipType)) {
-                Set<String> uniqueRelTypes = new HashSet<>();
-                for (String rel : relTypes) {
-                    uniqueRelTypes.add(rel);
-                }
-                relTypesStr = uniqueRelTypes.toString();
-            } else {
-                relTypesStr = relTypes.toString();
-            }
+    public List<ChatMessage> createUnstructuredPrompt(String text) {
+        // TODO - test with this
+        if (prompt != null && !prompt.isEmpty()) {
+            return prompt;
         }
 
+        // TODO - commonize
+        final boolean withAllowedNodes = allowedNodes != null && !allowedNodes.isEmpty();
+        String nodeLabelsStr = withAllowedNodes ? allowedNodes.toString() : "";
+        // TODO - commonize
+        final boolean withAllowedRels = allowedRelationships != null && !allowedRelationships.isEmpty();
+        String relTypesStr = withAllowedRels ? allowedRelationships.toString() : "";
+
+        // TODO - optimize
+        // TODO - use prompt template via promptTemplate.apply()
         String systemPrompt = String.join("\n", Arrays.asList(
                 "You are a top-tier algorithm designed for extracting information in structured formats to build a knowledge graph.",
                 "Your task is to identify entities and relations from a given text and generate output in JSON format.",
                 "Each object should have keys: 'head', 'head_type', 'relation', 'tail', and 'tail_type'.",
-                nodeLabels != null ? "The 'head_type' and 'tail_type' must be one of: " + nodeLabelsStr : "",
-                relTypes != null ? "The 'relation' must be one of: " + relTypesStr : "",
+                withAllowedNodes ? "The 'head_type' and 'tail_type' must be one of: " + nodeLabelsStr : "",
+                withAllowedRels ? "The 'relation' must be one of: " + relTypesStr : "",
                 "IMPORTANT NOTES:\n- Don't add any explanation or extra text.",
                 additionalInstructions
         ));
 
         final SystemMessage systemMessage = new SystemMessage(systemPrompt);
+        
+
+        final String examplesString = getString(examples);
 
         String humanPrompt = String.join("\n", Arrays.asList(
                 "Based on the following example, extract entities and relations from the provided text.",
-                nodeLabels != null ? "# ENTITY TYPES:\n" + nodeLabelsStr : "",
-                relTypes != null ? "# RELATION TYPES:\n" + relTypesStr : "",
+                withAllowedNodes ? "# ENTITY TYPES:\n" + nodeLabelsStr : "",
+                withAllowedRels ? "# RELATION TYPES:\n" + relTypesStr : "",
+                "Below are a number of examples of text and their extracted entities and relationships.",
+                examplesString,
+                additionalInstructions,
                 "For the following text, extract entities and relations as in the provided example.",
                 "Text: " + text
         ));
@@ -312,38 +167,24 @@ public class LLMGraphTransformer {
         return List.of(systemMessage, userMessage);
     }
 
+    private static String getString(List<Map<String, String>> examples1) {
+        final String examplesString;
+        try {
+            examplesString = new ObjectMapper().writeValueAsString(examples1);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+        return examplesString;
+    }
+
     private GraphDocument processResponse(Document document) {
-//        String text = document.getContent();
-        
-        /*
-        
-            TODO 
-           prompt = prompt or create_unstructured_prompt(
-                allowed_nodes,
-                allowed_relationships,
-                self._relationship_type,
-                additional_instructions,
-            )
-            
-            rawSchema = self.chain.invoke({"input": text}, config=config)
-         */
-        
-        // TODO - configurable chatLanguageModel
-        ChatLanguageModel chatModel = OpenAiChatModel.builder()
-                .baseUrl("demo")
-                .apiKey("demo")
-                .organizationId(System.getenv("OPENAI_ORGANIZATION_ID"))
-                .modelName("gpt-4o-mini")
-                .logRequests(true)
-                .logResponses(true)
-                .build();
 
         final String text = document.text();
         
         
         // todo - configurable, pr 
         //  use PromptTemplate handling via {{ }}
-        final List<ChatMessage> messages = createUnstructuredPrompt(text, null, null, null, "");
+        final List<ChatMessage> messages = createUnstructuredPrompt(text);
         // final PromptTemplate template = PromptTemplate.from(prompt);
 
         System.out.println("messages = " + messages);
@@ -351,18 +192,13 @@ public class LLMGraphTransformer {
 
         //final Prompt apply = template.apply(Map.of());
         //final String text1 = apply.text();
-        String rawSchema = chatModel.generate(messages).content().text();
-                // new MockLLMService().callLLM(text);
-
+        
         Set<Node> nodesSet = new HashSet<>();
         Set<Edge> relationships = new HashSet<>();
-
-        List<Map<String, String>> parsedJson = parseJson(rawSchema);
-        if (parsedJson == null) {
-            // TODO - EVALUATE A RETRY MECHANISM CONFIGURABLE
-            System.out.println("parsedJson = " + parsedJson);
-            return new GraphDocument(Set.of(), Set.of(), document);
-        }
+        
+        // TODO - DEPRECATED
+        List<Map<String, String>> parsedJson = getJsonResult(messages);
+        if (parsedJson == null) return null;
 
         for (Map<String, String> rel : parsedJson) {
             if (!rel.containsKey("head") || !rel.containsKey("tail") || !rel.containsKey("relation")) {
@@ -378,28 +214,40 @@ public class LLMGraphTransformer {
             final String relation = rel.get("relation");
             final Edge edge = new Edge(sourceNode, targetNode, relation);
             relationships.add(edge);
-//            relationships.add(new Edge(sourceNode.getId(), targetNode.getId(), rel.get("relation")));
         }
 
-//        List<Node> nodes = new ArrayList<>(nodesSet);
-        // TODO - REMOVE THE TOSTRING()
         return new GraphDocument(nodesSet, relationships, document);
 //        return new GraphDocument(nodes, relationships, document);
     }
 
-    private List<Map<String, String>> parseJson(String jsonString) {
+    private List<Map<String, String>> getJsonResult(List<ChatMessage> messages) {
+
+        List<Map<String, String>> parsedJson = RetryUtils.withRetry(() -> {
+            String rawSchema = model.generate(messages)
+                    .content()
+                    .text();
+            
+            // TODO - util??
+            // TODO - COMMENT THIS, can output json``` sometimes
+            rawSchema = rawSchema.replaceAll("```", "")
+                    .replaceAll("json", "");
+            
+            return parseJson(rawSchema);
+        }, maxAttempts);
+        
+//        if (parsedJson == null) {
+//            // TODO - EVALUATE A RETRY MECHANISM CONFIGURABLE
+//            System.out.println("parsedJson = " + parsedJson);
+//            return null;
+//        }
+        return parsedJson;
+    }
+
+    // TODO - util??
+    private <T> T parseJson(String jsonString) throws JsonProcessingException {
         ObjectMapper objectMapper = new ObjectMapper();
-        // TODO - COMMENT THIS, can output json``` sometimes
-        jsonString = jsonString.replaceAll("```", "")
-                .replaceAll("json", "");
-        try {
-            return objectMapper.readValue(jsonString, new TypeReference<List<Map<String, String>>>() {});
-        } catch (Exception e) {
-            System.out.println("e = " + e);
-            return null;
-            // throw new RuntimeException("Error parsing JSON", e);
-        }
-        // Placeholder for actual JSON parsing
+
+        return objectMapper.readValue(jsonString, new TypeReference<>() {});
     }
     
 //    public List<GraphDocument> convertToGraphDocuments(List<Document> documents) {
@@ -413,9 +261,9 @@ public class LLMGraphTransformer {
     // TODO - METTERE UPPERCASE PER LE RELAZIONI, PERCHE PUO CAPITARE is_on INVECE DI IS_ON
     //      CAPITALIZE LABEL???
     public void addGraphDocuments(Graph graph, List<GraphDocument> graphDocuments, boolean includeSource, boolean baseEntityLabel) {
-        if (baseEntityLabel && !graph.constraintExists("BaseEntity", "id")) {
-            graph.createConstraint("BaseEntity", "id");
-        }
+//        if (baseEntityLabel && !graph.constraintExists("BaseEntity", "id")) {
+//            graph.createConstraint("BaseEntity", "id");
+//        }
 
             // TODO - STA ROBA VA IN NEO4J
 //        for (GraphDocument doc : graphDocuments) {

--- a/langchain4j-neo4j/src/main/java/dev/langchain4j/transformer/LLMGraphTransformer.java
+++ b/langchain4j-neo4j/src/main/java/dev/langchain4j/transformer/LLMGraphTransformer.java
@@ -1,18 +1,16 @@
 package dev.langchain4j.transformer;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.data.document.Document;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.internal.RetryUtils;
 import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.input.PromptTemplate;
+import dev.langchain4j.rag.content.retriever.neo4j.Neo4jContentRetriever;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -21,20 +19,13 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static dev.langchain4j.transformer.GraphDocument.*;
-import dev.langchain4j.internal.RetryUtils;
-
-/**
- * TODO - vedere se lo fa da solo,
- * fare un document con Keanu Reeves e K. Reeves
- * se non lo fa, aggiustare il prompt magari? O forse tra le options?
- * https://chatgpt.com/c/67b8568b-db80-800c-8aab-b4c3f1fb434f
- * 
- */
-
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
-import static dev.langchain4j.transformer.LLMGraphTransformerUtils.*;
+import static dev.langchain4j.transformer.GraphDocument.Edge;
+import static dev.langchain4j.transformer.GraphDocument.Node;
+import static dev.langchain4j.transformer.LLMGraphTransformerUtils.EXAMPLES_PROMPT;
+import static dev.langchain4j.transformer.LLMGraphTransformerUtils.getStringFromListOfMaps;
+import static dev.langchain4j.transformer.LLMGraphTransformerUtils.parseJson;
 
 
 @Getter
@@ -60,8 +51,6 @@ public class LLMGraphTransformer {
     private final List<String> allowedNodes;
     private final List<String> allowedRelationships;
     private final List<ChatMessage> prompt;
-    private final boolean strictMode;
-    private final boolean ignoreToolUsage;
     private final String additionalInstructions;
     private final ChatLanguageModel model;
     private final List<Map<String, String>> examples;
@@ -77,8 +66,6 @@ public class LLMGraphTransformer {
      * @param allowedNodes Specifies which node types are allowed in the graph. If null or empty allows all node types (default: [])
      * @param allowedRelationships Specifies which relationship types are allowed in the graph. If null or empty allows all relationship types (default: [])
      * @param prompt TODO
-     * @param strictMode TODO
-     * @param ignoreToolUsage TODO
      * @param additionalInstructions Allows you to add additional instructions to the prompt without having to change the whole prompt (default: '')
      * @param examples Allows you to add additional instructions to the prompt without having to change the whole prompt (default: {@link LLMGraphTransformerUtils#EXAMPLES_PROMPT})
      * @param maxAttempts Retry N times the transformation if it fails (default: 1)
@@ -88,8 +75,6 @@ public class LLMGraphTransformer {
                                List<String> allowedNodes,
                                List<String> allowedRelationships,
                                List<ChatMessage> prompt,
-                               Boolean strictMode,
-                               Boolean ignoreToolUsage,
                                String additionalInstructions,
                                List<Map<String, String>> examples,
                                Integer maxAttempts) {
@@ -101,13 +86,6 @@ public class LLMGraphTransformer {
         this.prompt = prompt;
         
         this.maxAttempts = getOrDefault(maxAttempts, 1);
-        // TODO ??
-        this.strictMode = getOrDefault(strictMode, true);
-//        this.nodeProperties = nodeProperties;
-//        this.relationshipProperties = relationshipProperties;
-
-        // TODO ??
-        this.ignoreToolUsage = getOrDefault(ignoreToolUsage, false);
         this.additionalInstructions = getOrDefault(additionalInstructions, "");
         
         this.examples = getOrDefault(examples, EXAMPLES_PROMPT);
@@ -127,10 +105,9 @@ public class LLMGraphTransformer {
             return prompt;
         }
 
-        // TODO - commonize
         final boolean withAllowedNodes = allowedNodes != null && !allowedNodes.isEmpty();
         String nodeLabelsStr = withAllowedNodes ? allowedNodes.toString() : "";
-        // TODO - commonize
+        
         final boolean withAllowedRels = allowedRelationships != null && !allowedRelationships.isEmpty();
         String relTypesStr = withAllowedRels ? allowedRelationships.toString() : "";
 
@@ -140,21 +117,41 @@ public class LLMGraphTransformer {
                 "You are a top-tier algorithm designed for extracting information in structured formats to build a knowledge graph.",
                 "Your task is to identify entities and relations from a given text and generate output in JSON format.",
                 "Each object should have keys: 'head', 'head_type', 'relation', 'tail', and 'tail_type'.",
-                withAllowedNodes ? "The 'head_type' and 'tail_type' must be one of: " + nodeLabelsStr : "",
-                withAllowedRels ? "The 'relation' must be one of: " + relTypesStr : "",
+                withAllowedNodes ? "The 'head_type' and 'tail_type' must be one of: " + allowedNodes.toString() : "",
+                withAllowedRels ? "The 'relation' must be one of: " + allowedRelationships.toString() : "",
                 "IMPORTANT NOTES:\n- Don't add any explanation or extra text.",
                 additionalInstructions
         ));
 
-        final SystemMessage systemMessage = new SystemMessage(systemPrompt);
+        final PromptTemplate from = PromptTemplate.from(
+                """
+                        You are a top-tier algorithm designed for extracting information in structured formats to build a knowledge graph.
+                        Your task is to identify entities and relations from a given text and generate output in JSON format.
+                        Each object should have keys: 'head', 'head_type', 'relation', 'tail', and 'tail_type'.
+                        {{nodes}}
+                        {{rels}}
+                        IMPORTANT NOTES:\n- Don't add any explanation or extra text.
+                        {{additional}}
+                        """
+        );
+
+//        final Prompt systemPrompt = 
+
+        final SystemMessage systemMessage = from.apply(
+                Map.of(
+                        "nodes", withAllowedNodes ? "The 'head_type' and 'tail_type' must be one of: " + allowedNodes.toString() : "",
+                        "rels", withAllowedRels ? "The 'relation' must be one of: " + allowedRelationships.toString() : "",
+                        "additional", additionalInstructions
+                )
+        ).toSystemMessage();
         
 
-        final String examplesString = getString(examples);
+        final String examplesString = getStringFromListOfMaps(EXAMPLES_PROMPT);
 
         String humanPrompt = String.join("\n", Arrays.asList(
                 "Based on the following example, extract entities and relations from the provided text.",
-                withAllowedNodes ? "# ENTITY TYPES:\n" + nodeLabelsStr : "",
-                withAllowedRels ? "# RELATION TYPES:\n" + relTypesStr : "",
+                withAllowedNodes ? "# ENTITY TYPES:\n" + allowedNodes.toString() : "",
+                withAllowedRels ? "# RELATION TYPES:\n" + allowedRelationships.toString() : "",
                 "Below are a number of examples of text and their extracted entities and relationships.",
                 examplesString,
                 additionalInstructions,
@@ -162,19 +159,29 @@ public class LLMGraphTransformer {
                 "Text: " + text
         ));
 
-        final UserMessage userMessage = new UserMessage(humanPrompt);
+        final PromptTemplate from1 = PromptTemplate.from("""
+                Based on the following example, extract entities and relations from the provided text.
+                {{nodes}}
+                {{rels}}
+                Below are a number of examples of text and their extracted entities and relationships.
+                {{examples}}
+                {{additional}}
+                For the following text, extract entities and relations as in the provided example.
+                Text: {{input}}
+                """);
+
+        final UserMessage userMessage = from1.apply(
+                Map.of(
+                        "nodes", withAllowedNodes ? "# ENTITY TYPES:\n" + allowedNodes.toString() : "",
+                        "rels", withAllowedRels ? "# RELATION TYPES:\n" + allowedRelationships.toString() : "",
+                        "examples", examplesString,
+                        "additional", additionalInstructions,
+                        "input", text
+                )
+        ).toUserMessage();
+//                new UserMessage(humanPrompt);
 
         return List.of(systemMessage, userMessage);
-    }
-
-    private static String getString(List<Map<String, String>> examples1) {
-        final String examplesString;
-        try {
-            examplesString = new ObjectMapper().writeValueAsString(examples1);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
-        return examplesString;
     }
 
     private GraphDocument processResponse(Document document) {
@@ -233,80 +240,13 @@ public class LLMGraphTransformer {
                     .content()
                     .text();
             
-            // TODO - util??
-            // TODO - COMMENT THIS, can output json``` sometimes
-            rawSchema = rawSchema.replaceAll("```", "")
-                    .replaceAll("json", "");
-            
+            rawSchema = Neo4jContentRetriever.getString(rawSchema);
+
             return parseJson(rawSchema);
         }, maxAttempts);
         
-//        if (parsedJson == null) {
-//            // TODO - EVALUATE A RETRY MECHANISM CONFIGURABLE
-//            System.out.println("parsedJson = " + parsedJson);
-//            return null;
-//        }
         return parsedJson;
     }
 
     // TODO - util??
-    private <T> T parseJson(String jsonString) throws JsonProcessingException {
-        ObjectMapper objectMapper = new ObjectMapper();
-
-        return objectMapper.readValue(jsonString, new TypeReference<>() {});
-    }
-    
-//    public List<GraphDocument> convertToGraphDocuments(List<Document> documents) {
-//        return documents.stream()
-//                .map(doc -> new GraphDocument(doc.getId(), doc.getContent()))
-//                .collect(Collectors.toList());
-//    }
-
-    // TODO - QUESTO IN REALTA DOVREBBE VERAMENTE GENERARE ENTITÀ
-    //  QUINDI VA IN UNA CLASSE SEPARATA IN TEORIA...
-    // TODO - METTERE UPPERCASE PER LE RELAZIONI, PERCHE PUO CAPITARE is_on INVECE DI IS_ON
-    //      CAPITALIZE LABEL???
-    public void addGraphDocuments(Graph graph, List<GraphDocument> graphDocuments, boolean includeSource, boolean baseEntityLabel) {
-//        if (baseEntityLabel && !graph.constraintExists("BaseEntity", "id")) {
-//            graph.createConstraint("BaseEntity", "id");
-//        }
-
-            // TODO - STA ROBA VA IN NEO4J
-//        for (GraphDocument doc : graphDocuments) {
-//            if (doc.getId() == null || doc.getId().isEmpty()) {
-//                doc.setId(generateMD5(doc.getContent()));
-//            }
-//
-//            for (Node node : doc.getNodes()) {
-//                node.setType(removeBackticks(node.getType()));
-//                graph.addNode(node);
-//            }
-//
-//            for (Edge edge : doc.getRelationships()) {
-//                edge.setSourceLabel(removeBackticks(edge.getSourceLabel()));
-//                edge.setTargetLabel(removeBackticks(edge.getTargetLabel()));
-//                edge.setType(removeBackticks(edge.getType().replace(" ", "_").toUpperCase()));
-//                graph.addEdge(edge);
-//            }
-//        }
-    }
-
-    public static String generateMD5(String input) {
-        try {
-            MessageDigest md = MessageDigest.getInstance("MD5");
-            md.update(input.getBytes());
-            byte[] digest = md.digest();
-            StringBuilder sb = new StringBuilder();
-            for (byte b : digest) {
-                sb.append(String.format("%02x", b));
-            }
-            return sb.toString();
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException("MD5 algorithm not found", e);
-        }
-    }
-
-    public static String removeBackticks(String input) {
-        return input.replace("`", "");
-    }
 }

--- a/langchain4j-neo4j/src/main/java/dev/langchain4j/transformer/LLMGraphTransformer1.java
+++ b/langchain4j-neo4j/src/main/java/dev/langchain4j/transformer/LLMGraphTransformer1.java
@@ -1,0 +1,455 @@
+//package dev.langchain4j.transformer;
+//
+//import com.fasterxml.jackson.core.type.TypeReference;
+//import com.fasterxml.jackson.databind.ObjectMapper;
+//import dev.langchain4j.data.document.Document;
+//import dev.langchain4j.data.message.ChatMessage;
+//import dev.langchain4j.data.message.SystemMessage;
+//import dev.langchain4j.data.message.UserMessage;
+//import dev.langchain4j.model.chat.ChatLanguageModel;
+//import dev.langchain4j.model.openai.OpenAiChatModel;
+//
+//import java.util.Arrays;
+//import java.util.HashSet;
+//import java.util.List;
+//import java.util.Map;
+//import java.util.Set;
+//import java.util.stream.Collectors;
+//
+//import java.security.MessageDigest;
+//import java.security.NoSuchAlgorithmException;
+//
+//import static dev.langchain4j.model.openai.OpenAiChatModelName.GPT_4_O_MINI;
+//
+//// TODO --- vedere la parte # Strict mode filtering in python
+//
+///* TODO
+//    The baseEntityLabel parameter assigns an additional __Entity__ label to each node, 
+//    enhancing indexing and query performance.
+//    The include_source parameter links nodes to their originating documents, 
+//    facilitating data traceability and context understanding.
+// */
+//
+///* TODO 
+//    # Extract graph data
+//    graph_documents = llm_transformer.convert_to_graph_documents(documents)
+//    # Store to neo4j
+//    graph.add_graph_documents(
+//      graph_documents, 
+//      baseEntityLabel=True, 
+//      include_source=True
+//    )
+// */
+//
+//public class LLMGraphTransformer1 {
+//
+//    public static class Graph {
+//        private List<Node> nodes;
+//        private List<Edge> edges;
+//
+//        public Graph() {
+//            this.nodes = new java.util.ArrayList<>();
+//            this.edges = new java.util.ArrayList<>();
+//        }
+//
+//        public void addNode(Node node) {
+//            nodes.add(node);
+//        }
+//
+//        public void addEdge(Edge edge) {
+//            edges.add(edge);
+//        }
+//
+//        public List<Node> getNodes() {
+//            return nodes;
+//        }
+//
+//        public List<Edge> getEdges() {
+//            return edges;
+//        }
+//
+//        public boolean constraintExists(String label, String property) {
+//            return false; // Placeholder for actual implementation
+//        }
+//
+//        public void createConstraint(String label, String property) {
+//            // Placeholder for actual implementation
+//        }
+//    }
+//
+//    
+//    public static class Node {
+//        private String id;
+////        private String data;
+//        private String type;
+//
+//        public Node(String id, String type) {
+//            this.id = id;
+//            this.type = type;
+//        }
+//
+//        public String getId() {
+//            return id;
+//        }
+//
+////        public String getData() {
+////            return data;
+////        }
+//
+//        public String getType() {
+//            return type;
+//        }
+//
+//        public void setType(String type) {
+//            this.type = type;
+//        }
+//    }
+//
+//    public static class Edge {
+////        private String from;
+////        private String to;
+//        private Node sourceNode;
+//        private Node targetNode;
+//        private String type;
+//
+//        public Edge(final Node sourceNode, final Node targetNode, final String type) {
+//            this.sourceNode = sourceNode;
+//            this.targetNode = targetNode;
+//            this.type = type;
+//        }
+//
+//        public Node getSourceNode() {
+//            return sourceNode;
+//        }
+//
+//        public Node getTargetNode() {
+//            return targetNode;
+//        }
+//
+//        public String getType() {
+//            return type;
+//        }
+//
+//        //        public Edge(Node sourceNode, Node targetNode, String type) {
+////            this.from = from;
+////            this.to = to;
+////        }
+////
+////        public String getSourceLabel() {
+////            return sourceLabel;
+////        }
+////
+////        public String getTargetLabel() {
+////            return targetLabel;
+////        }
+////
+////        public String getType() {
+////            return type;
+////        }
+////
+////        public String getFrom() {
+////            return from;
+////        }
+////
+////        public String getTo() {
+////            return to;
+////        }
+////
+////        public void setSourceLabel(String sourceLabel) {
+////            this.sourceLabel = sourceLabel;
+////        }
+////
+////        public void setTargetLabel(String targetLabel) {
+////            this.targetLabel = targetLabel;
+////        }
+////
+////        public void setType(String type) {
+////            this.type = type;
+////        }
+//    }
+//
+//    // TODO - WHAT???
+//    interface LLMService {
+//        String callLLM(String prompt);
+//    }
+//
+//    // TODO - substitute to Document of Langchain4j
+////    static class Document {
+////        private String id;
+////        private String content;
+////
+////        public Document(String id, String content) {
+////            this.id = id;
+////            this.content = content;
+////        }
+////
+////        public String getId() {
+////            return id;
+////        }
+////
+////        public String getContent() {
+////            return content;
+////        }
+////    }
+//
+//    public static class GraphDocument {
+////        private String id;
+////        private String content;
+//        private Set<Node> nodes;
+//        private Set<Edge> relationships;
+//        private Document source;
+//
+//        public GraphDocument(Set<Node> nodes, Set<Edge> relationships, Document source) {
+//            this.nodes = nodes;
+//            this.relationships = relationships;
+//            this.source = source;
+//        }
+//
+////        public String getId() {
+////            return id;
+////        }
+////
+////        public String getContent() {
+////            return content;
+////        }
+////
+////        public void setId(String id) {
+////            this.id = id;
+////        }
+//
+//
+//        public Document getSource() {
+//            return source;
+//        }
+//
+//        public Set<Node> getNodes() {
+//            return nodes;
+//        }
+//
+//        public Set<Edge> getRelationships() {
+//            return relationships;
+//        }
+//    }
+//
+//
+//    // TODO - SPLIT CLASSES
+//    
+////    private final LLMService llmService;
+//
+//    // TODO - use @Builder
+//    public LLMGraphTransformer(/*LLMService llmService*/) {
+////        this.llmService = llmService;
+//    }
+//
+////    public Graph transform(Graph graph) {
+////        Graph transformedGraph = new Graph();
+////
+////        for (Node node : graph.getNodes()) {
+////            Node transformedNode = transformNode(node);
+////            transformedGraph.addNode(transformedNode);
+////        }
+////
+////        for (Edge edge : graph.getEdges()) {
+////            transformedGraph.addEdge(edge);
+////        }
+////
+////        return transformedGraph;
+////    }
+////
+////    private Node transformNode(Node node) {
+////        String prompt = "Transform this node: " + node.getData();
+////        String transformedData = llmService.callLLM(prompt);
+////        return new Node(node.getId(), transformedData);
+////    }
+//
+//    public List<GraphDocument> convertToGraphDocuments(List<Document> documents) {
+//        // TODO - MAGARI METTERE ANCHE UN FILTER IS NOT NULL
+//        return documents.stream().map(this::processResponse).collect(Collectors.toList());
+//    }
+//
+//    public List<ChatMessage> createUnstructuredPrompt(String text, List<String> nodeLabels, List<String> relTypes, String relationshipType, String additionalInstructions) {
+//        String nodeLabelsStr = nodeLabels != null ? nodeLabels.toString() : "";
+//        String relTypesStr = "";
+//        if (relTypes != null) {
+//            if ("tuple".equals(relationshipType)) {
+//                Set<String> uniqueRelTypes = new HashSet<>();
+//                for (String rel : relTypes) {
+//                    uniqueRelTypes.add(rel);
+//                }
+//                relTypesStr = uniqueRelTypes.toString();
+//            } else {
+//                relTypesStr = relTypes.toString();
+//            }
+//        }
+//
+//        String systemPrompt = String.join("\n", Arrays.asList(
+//                "You are a top-tier algorithm designed for extracting information in structured formats to build a knowledge graph.",
+//                "Your task is to identify entities and relations from a given text and generate output in JSON format.",
+//                "Each object should have keys: 'head', 'head_type', 'relation', 'tail', and 'tail_type'.",
+//                nodeLabels != null ? "The 'head_type' and 'tail_type' must be one of: " + nodeLabelsStr : "",
+//                relTypes != null ? "The 'relation' must be one of: " + relTypesStr : "",
+//                "IMPORTANT NOTES:\n- Don't add any explanation or extra text.",
+//                additionalInstructions
+//        ));
+//
+//        final SystemMessage systemMessage = new SystemMessage(systemPrompt);
+//
+//        String humanPrompt = String.join("\n", Arrays.asList(
+//                "Based on the following example, extract entities and relations from the provided text.",
+//                nodeLabels != null ? "# ENTITY TYPES:\n" + nodeLabelsStr : "",
+//                relTypes != null ? "# RELATION TYPES:\n" + relTypesStr : "",
+//                "For the following text, extract entities and relations as in the provided example.",
+//                "Text: " + text
+//        ));
+//
+//        final UserMessage userMessage = new UserMessage(humanPrompt);
+//
+//        return List.of(systemMessage, userMessage);
+//    }
+//
+//    private GraphDocument processResponse(Document document) {
+////        String text = document.getContent();
+//        
+//        /*
+//        
+//            TODO 
+//           prompt = prompt or create_unstructured_prompt(
+//                allowed_nodes,
+//                allowed_relationships,
+//                self._relationship_type,
+//                additional_instructions,
+//            )
+//            
+//            rawSchema = self.chain.invoke({"input": text}, config=config)
+//         */
+//        
+//        // TODO - configurable chatLanguageModel
+//        ChatLanguageModel chatModel = OpenAiChatModel.builder()
+//                .baseUrl("http://langchain4j.dev/demo/openai/v1")
+//                .apiKey("demo")
+//                .organizationId(System.getenv("OPENAI_ORGANIZATION_ID"))
+//                .modelName(GPT_4_O_MINI)
+//                .logRequests(true)
+//                .logResponses(true)
+//                .build();
+//
+//        final String text = document.text();
+//        
+//        
+//        // todo - configurable, pr 
+//        //  use PromptTemplate handling via {{ }}
+//        final List<ChatMessage> messages = createUnstructuredPrompt(text, null, null, null, "");
+//        // final PromptTemplate template = PromptTemplate.from(prompt);
+//
+//        System.out.println("messages = " + messages);
+//        // TODO -- PromptTemplate
+//
+//        //final Prompt apply = template.apply(Map.of());
+//        //final String text1 = apply.text();
+//        
+//        // TODO - DEPRECATED
+//        String rawSchema = chatModel.generate(messages).content().text();
+//                // new MockLLMService().callLLM(text);
+//
+//        Set<Node> nodesSet = new HashSet<>();
+//        Set<Edge> relationships = new HashSet<>();
+//
+//        List<Map<String, String>> parsedJson = parseJson(rawSchema);
+//        if (parsedJson == null) {
+//            // TODO - EVALUATE A RETRY MECHANISM CONFIGURABLE
+//            System.out.println("parsedJson = " + parsedJson);
+//            return new GraphDocument(Set.of(), Set.of(), document);
+//        }
+//
+//        for (Map<String, String> rel : parsedJson) {
+//            if (!rel.containsKey("head") || !rel.containsKey("tail") || !rel.containsKey("relation")) {
+//                continue;
+//            }
+//
+//            Node sourceNode = new Node(rel.get("head"), rel.getOrDefault("head_type", "DefaultNodeType"));
+//            Node targetNode = new Node(rel.get("tail"), rel.getOrDefault("tail_type", "DefaultNodeType"));
+//
+//            nodesSet.add(sourceNode);
+//            nodesSet.add(targetNode);
+//
+//            final String relation = rel.get("relation");
+//            final Edge edge = new Edge(sourceNode, targetNode, relation);
+//            relationships.add(edge);
+////            relationships.add(new Edge(sourceNode.getId(), targetNode.getId(), rel.get("relation")));
+//        }
+//
+////        List<Node> nodes = new ArrayList<>(nodesSet);
+//        // TODO - REMOVE THE TOSTRING()
+//        return new GraphDocument(nodesSet, relationships, document);
+////        return new GraphDocument(nodes, relationships, document);
+//    }
+//
+//    private List<Map<String, String>> parseJson(String jsonString) {
+//        ObjectMapper objectMapper = new ObjectMapper();
+//        // TODO - COMMENT THIS, can output json``` sometimes
+//        jsonString = jsonString.replaceAll("```", "")
+//                .replaceAll("json", "");
+//        try {
+//            return objectMapper.readValue(jsonString, new TypeReference<List<Map<String, String>>>() {});
+//        } catch (Exception e) {
+//            System.out.println("e = " + e);
+//            return null;
+//            // throw new RuntimeException("Error parsing JSON", e);
+//        }
+//        // Placeholder for actual JSON parsing
+//    }
+//    
+////    public List<GraphDocument> convertToGraphDocuments(List<Document> documents) {
+////        return documents.stream()
+////                .map(doc -> new GraphDocument(doc.getId(), doc.getContent()))
+////                .collect(Collectors.toList());
+////    }
+//
+//    // TODO - QUESTO IN REALTA DOVREBBE VERAMENTE GENERARE ENTITÀ
+//    //  QUINDI VA IN UNA CLASSE SEPARATA IN TEORIA...
+//    // TODO - METTERE UPPERCASE PER LE RELAZIONI, PERCHE PUO CAPITARE is_on INVECE DI IS_ON
+//    //      CAPITALIZE LABEL???
+//    public void addGraphDocuments(Graph graph, List<GraphDocument> graphDocuments, boolean includeSource, boolean baseEntityLabel) {
+//        if (baseEntityLabel && !graph.constraintExists("BaseEntity", "id")) {
+//            graph.createConstraint("BaseEntity", "id");
+//        }
+//
+//            // TODO - STA ROBA VA IN NEO4J
+////        for (GraphDocument doc : graphDocuments) {
+////            if (doc.getId() == null || doc.getId().isEmpty()) {
+////                doc.setId(generateMD5(doc.getContent()));
+////            }
+////
+////            for (Node node : doc.getNodes()) {
+////                node.setType(removeBackticks(node.getType()));
+////                graph.addNode(node);
+////            }
+////
+////            for (Edge edge : doc.getRelationships()) {
+////                edge.setSourceLabel(removeBackticks(edge.getSourceLabel()));
+////                edge.setTargetLabel(removeBackticks(edge.getTargetLabel()));
+////                edge.setType(removeBackticks(edge.getType().replace(" ", "_").toUpperCase()));
+////                graph.addEdge(edge);
+////            }
+////        }
+//    }
+//
+//    public static String generateMD5(String input) {
+//        try {
+//            MessageDigest md = MessageDigest.getInstance("MD5");
+//            md.update(input.getBytes());
+//            byte[] digest = md.digest();
+//            StringBuilder sb = new StringBuilder();
+//            for (byte b : digest) {
+//                sb.append(String.format("%02x", b));
+//            }
+//            return sb.toString();
+//        } catch (NoSuchAlgorithmException e) {
+//            throw new RuntimeException("MD5 algorithm not found", e);
+//        }
+//    }
+//
+//    public static String removeBackticks(String input) {
+//        return input.replace("`", "");
+//    }
+//}

--- a/langchain4j-neo4j/src/main/java/dev/langchain4j/transformer/LLMGraphTransformer2.java
+++ b/langchain4j-neo4j/src/main/java/dev/langchain4j/transformer/LLMGraphTransformer2.java
@@ -1,0 +1,482 @@
+//package dev.langchain4j.transformer;
+//
+//import com.fasterxml.jackson.core.type.TypeReference;
+//import com.fasterxml.jackson.databind.ObjectMapper;
+//import dev.langchain4j.data.document.Document;
+//import dev.langchain4j.data.message.ChatMessage;
+//import dev.langchain4j.data.message.SystemMessage;
+//import dev.langchain4j.data.message.UserMessage;
+//import dev.langchain4j.model.chat.ChatLanguageModel;
+//import dev.langchain4j.model.openai.OpenAiChatModel;
+//import lombok.Builder;
+//import lombok.Getter;
+//
+//import java.security.MessageDigest;
+//import java.security.NoSuchAlgorithmException;
+//import java.util.Arrays;
+//import java.util.HashSet;
+//import java.util.List;
+//import java.util.Map;
+//import java.util.Objects;
+//import java.util.Set;
+//import java.util.stream.Collectors;
+//
+//import static dev.langchain4j.internal.Utils.getOrDefault;
+//import static dev.langchain4j.model.openai.OpenAiChatModelName.GPT_4_O_MINI;
+//import static dev.langchain4j.transformer.GraphDocument.Edge;
+//import static dev.langchain4j.transformer.GraphDocument.Node;
+//
+//// TODO --- vedere la parte # Strict mode filtering in python
+//
+///* TODO
+//    The baseEntityLabel parameter assigns an additional __Entity__ label to each node, 
+//    enhancing indexing and query performance.
+//    The include_source parameter links nodes to their originating documents, 
+//    facilitating data traceability and context understanding.
+// */
+//
+///* TODO 
+//    # Extract graph data
+//    graph_documents = llm_transformer.convert_to_graph_documents(documents)
+//    # Store to neo4j
+//    graph.add_graph_documents(
+//      graph_documents, 
+//      baseEntityLabel=True, 
+//      include_source=True
+//    )
+// */
+//
+//@Getter
+//public class LLMGraphTransformer2 {
+//
+//
+//    // TODO - WHAT???
+//    interface LLMService {
+//        String callLLM(String prompt);
+//    }
+//
+//    // TODO - substitute to Document of Langchain4j
+////    static class Document {
+////        private String id;
+////        private String content;
+////
+////        public Document(String id, String content) {
+////            this.id = id;
+////            this.content = content;
+////        }
+////
+////        public String getId() {
+////            return id;
+////        }
+////
+////        public String getContent() {
+////            return content;
+////        }
+////    }
+//
+//
+//    /*
+//    TODO - RICOPIARE QUESTO COMMENTO
+//    
+//    """Transform documents into graph-based documents using a LLM.
+//
+//    It allows specifying constraints on the types of nodes and relationships to include
+//    in the output graph. The class supports extracting properties for both nodes and
+//    relationships.
+//
+//    Args:
+//        llm (BaseLanguageModel): An instance of a language model supporting structured
+//          output.
+//        allowed_nodes (List[str], optional): Specifies which node types are
+//          allowed in the graph. Defaults to an empty list, allowing all node types.
+//        allowed_relationships (List[str], optional): Specifies which relationship types
+//          are allowed in the graph. Defaults to an empty list, allowing all relationship
+//          types.
+//        prompt (Optional[ChatPromptTemplate], optional): The prompt to pass to
+//          the LLM with additional instructions.
+//        strict_mode (bool, optional): Determines whether the transformer should apply
+//          filtering to strictly adhere to `allowed_nodes` and `allowed_relationships`.
+//          Defaults to True.
+//        node_properties (Union[bool, List[str]]): If True, the LLM can extract any
+//          node properties from text. Alternatively, a list of valid properties can
+//          be provided for the LLM to extract, restricting extraction to those specified.
+//        relationship_properties (Union[bool, List[str]]): If True, the LLM can extract
+//          any relationship properties from text. Alternatively, a list of valid
+//          properties can be provided for the LLM to extract, restricting extraction to
+//          those specified.
+//        ignore_tool_usage (bool): Indicates whether the transformer should
+//          bypass the use of structured output functionality of the language model.
+//          If set to True, the transformer will not use the language model's native
+//          function calling capabilities to handle structured output. Defaults to False.
+//        additional_instructions (str): Allows you to add additional instructions
+//          to the prompt without having to change the whole prompt.
+//
+//    Example:
+//        .. code-block:: python
+//            from langchain_experimental.graph_transformers import LLMGraphTransformer
+//            from langchain_core.documents import Document
+//            from langchain_openai import ChatOpenAI
+//
+//            llm=ChatOpenAI(temperature=0)
+//            transformer = LLMGraphTransformer(
+//                llm=llm,
+//                allowed_nodes=["Person", "Organization"])
+//
+//            doc = Document(page_content="Elon Musk is suing OpenAI")
+//            graph_documents = transformer.convert_to_graph_documents([doc])
+//     */
+//
+//    /*
+//            self,
+//        llm: BaseLanguageModel,
+//        allowed_nodes: List[str] = [],
+//        allowed_relationships: Union[List[str], List[Tuple[str, str, str]]] = [],
+//        prompt: Optional[ChatPromptTemplate] = None,
+//        strict_mode: bool = True,
+//        node_properties: Union[bool, List[str]] = False,
+//        relationship_properties: Union[bool, List[str]] = False,
+//        ignore_tool_usage: bool = False,
+//        additional_instructions: str = "",
+//     */
+//
+//    /*
+//    A general concept of NER / Entity / Relationship extraction
+//    Then processing / storing these entities in databases .e.g graph databases like neo4j (but relational would work as well)
+//    TODO - done via allowedNodes, allowedRelationships, Options for providing graph schema and additional extraction for the construction
+//    TODO Option to link entities back to the source document
+//    TODO Entity de-duplication with the LLM and possibly other methods (slightly different spelling of names/ids)
+//    TODO Additional metadata about the entities and their relationships (e.g. facts, claims, confidence-scores)
+//    TODO - JUST A FACT These knowledge graphs form the foundation for advanced RAG patterns in GraphRAG (see https://graphrag.com)
+//    TODO- JUST A FACT, WRITE ON THE PR Besides data from document loaders also data that already exists in large text fields in databases (semi-structured data) could be analyzed and extracted
+//    This also offers the means to then run additional algorithms on the data e.g. for query focused summarization that compute communities/clusters of topics and summarize them with an LLM
+//     */
+//
+//    private final List<String> allowedNodes;
+//    private final List<String> allowedRelationships;
+//    private final List<ChatMessage> prompt;
+//    private final boolean strictMode;
+////    private final Object nodeProperties;
+////    private final Object relationshipProperties;
+//    private final boolean ignoreToolUsage;
+//    private final String additionalInstructions;
+//    
+//    // TODO - use @Builder
+//    @Builder
+//    public LLMGraphTransformer2(List<String> allowedNodes,
+//                                List<String> allowedRelationships,
+//                                List<ChatMessage> prompt,
+//                                Boolean strictMode,
+////                               Object nodeProperties,
+////                               Object relationshipProperties,
+//                                Boolean ignoreToolUsage,
+//                                String additionalInstructions) {
+//        
+//        this.allowedNodes = getOrDefault(allowedNodes, List.of());
+//        this.allowedRelationships = getOrDefault(allowedRelationships, List.of());
+//        this.prompt = prompt;
+//        this.strictMode = getOrDefault(strictMode, true);
+////        this.nodeProperties = nodeProperties;
+////        this.relationshipProperties = relationshipProperties;
+//        this.ignoreToolUsage = getOrDefault(ignoreToolUsage, false);
+//        this.additionalInstructions = getOrDefault(additionalInstructions, "");
+//        
+////        this.llmService = llmService;
+//    }
+//
+////    public Graph transform(Graph graph) {
+////        Graph transformedGraph = new Graph();
+////
+////        for (Node node : graph.getNodes()) {
+////            Node transformedNode = transformNode(node);
+////            transformedGraph.addNode(transformedNode);
+////        }
+////
+////        for (Edge edge : graph.getEdges()) {
+////            transformedGraph.addEdge(edge);
+////        }
+////
+////        return transformedGraph;
+////    }
+////
+////    private Node transformNode(Node node) {
+////        String prompt = "Transform this node: " + node.getData();
+////        String transformedData = llmService.callLLM(prompt);
+////        return new Node(node.getId(), transformedData);
+////    }
+//
+//    public List<GraphDocument> convertToGraphDocuments(List<Document> documents) {
+//        return documents.stream().map(this::processResponse)
+//                .filter(Objects::nonNull)
+//                .collect(Collectors.toList());
+//    }
+//
+//    public List<ChatMessage> createUnstructuredPrompt(String text/*, List<String> nodeLabels, List<String> relTypes, String relationshipType, String additionalInstructions*/) {
+//        // TODO - test with this
+//        if (prompt != null && !prompt.isEmpty()) {
+//            return prompt;
+//        }
+//        
+//        String nodeLabelsStr = allowedNodes != null ? allowedNodes.toString() : "";
+//        String relTypesStr = "";
+//        if (allowedRelationships != null) {
+////            if ("tuple".equals(relationshipType)) {
+////                Set<String> uniqueRelTypes = new HashSet<>();
+////                for (String rel : relTypes) {
+////                    uniqueRelTypes.add(rel);
+////                }
+////                relTypesStr = uniqueRelTypes.toString();
+////            } else {
+//                relTypesStr = allowedRelationships.toString();
+////            }
+//        }
+//        
+//        /* TODO
+//        StringBuilder message = new StringBuilder();
+//
+//if (relTypes != null && !relTypes.isEmpty()) {
+//    message.append("");  // Equivalent to Python's `else ""`
+//}
+//
+//if (nodeLabels != null && !nodeLabels.isEmpty()) {
+//    message.append(String.format(
+//        "The \"tail\" key must represent the text of an extracted entity which is " +
+//        "the tail of the relation, and the \"tail_type\" key must contain the type " +
+//        "of the tail entity from %s.", nodeLabelsStr
+//    ));
+//} else {
+//    message.append(""); // Equivalent to Python's `else ""`
+//}
+//
+//if ("tuple".equals(relationshipType)) {
+//    message.append(String.format(
+//        "Your task is to extract relationships from text strictly adhering " +
+//        "to the provided schema. The relationships can only appear " +
+//        "between specific node types are presented in the schema format " +
+//        "like: (Entity1Type, RELATIONSHIP_TYPE, Entity2Type) /n" +
+//        "Provided schema is %s.", relTypes
+//    ));
+//} else {
+//    message.append("");
+//}
+//
+//message.append(
+//    "Attempt to extract as many entities and relations as you can. Maintain " +
+//    "Entity Consistency: When extracting entities, it's vital to ensure " +
+//    "consistency. If an entity, such as \"John Doe\", is mentioned multiple " +
+//    "times in the text but is referred to by different names or pronouns " +
+//    "(e.g., \"Joe\", \"he\"), always use the most complete identifier for " +
+//    "that entity. The knowledge graph should be coherent and easily " +
+//    "understandable, so maintaining consistency in entity references is " +
+//    "crucial."
+//);
+//
+//message.append("IMPORTANT NOTES:\n- Don't add any explanation and text. ");
+//
+//String finalMessage = message.toString(); // Convert StringBuilder to String
+//
+//         */
+//
+//        // TODO - optimize
+//        String systemPrompt = String.join("\n", Arrays.asList(
+//                "You are a top-tier algorithm designed for extracting information in structured formats to build a knowledge graph.",
+//                "Your task is to identify entities and relations from a given text and generate output in JSON format.",
+//                "Each object should have keys: 'head', 'head_type', 'relation', 'tail', and 'tail_type'.",
+//                allowedNodes != null ? "The 'head_type' and 'tail_type' must be one of: " + nodeLabelsStr : "",
+//                allowedRelationships != null ? "The 'relation' must be one of: " + relTypesStr : "",
+//                "IMPORTANT NOTES:\n- Don't add any explanation or extra text.",
+//                additionalInstructions
+//        ));
+//
+//        final SystemMessage systemMessage = new SystemMessage(systemPrompt);
+//
+//        /* TODO
+//        List<String> parts = new ArrayList<>();
+//
+//if (relTypes != null && !relTypes.isEmpty()) {
+//    parts.add(""); // Equivalent to Python's `else ""`
+//}
+//
+//if ("tuple".equals(relationshipType)) {
+//    parts.add(String.format(
+//        "Your task is to extract relationships from text strictly adhering " +
+//        "to the provided schema. The relationships can only appear " +
+//        "between specific node types presented in the schema format " +
+//        "like: (Entity1Type, RELATIONSHIP_TYPE, Entity2Type) /n" +
+//        "Provided schema is %s.", relTypes
+//    ));
+//}
+//
+//parts.add("Below are a number of examples of text and their extracted " +
+//          "entities and relationships.\n{examples}\n");
+//
+//if (additionalInstructions != null && !additionalInstructions.isEmpty()) {
+//    parts.add(additionalInstructions);
+//}
+//
+//parts.add("For the following text, extract entities and relations as " +
+//          "in the provided example.\n" +
+//          "{format_instructions}\nText: {input}");
+//
+//String finalMessage = String.join("\n", parts);
+//
+//         */
+//        
+//        String humanPrompt = String.join("\n", Arrays.asList(
+//                "Based on the following example, extract entities and relations from the provided text.",
+//                allowedNodes != null ? "# ENTITY TYPES:\n" + nodeLabelsStr : "",
+//                allowedRelationships != null ? "# RELATION TYPES:\n" + relTypesStr : "",
+//                "For the following text, extract entities and relations as in the provided example.",
+//                "Text: " + text
+//        ));
+//
+//        final UserMessage userMessage = new UserMessage(humanPrompt);
+//
+//        return List.of(systemMessage, userMessage);
+//    }
+//
+//    private GraphDocument processResponse(Document document) {
+//        
+//        /*
+//        
+//            TODO 
+//           prompt = prompt or create_unstructured_prompt(
+//                allowed_nodes,
+//                allowed_relationships,
+//                self._relationship_type,
+//                additional_instructions,
+//            )
+//            
+//            rawSchema = self.chain.invoke({"input": text}, config=config)
+//         */
+//        
+//        // TODO - configurable chatLanguageModel
+//        ChatLanguageModel chatModel = OpenAiChatModel.builder()
+//                .baseUrl("http://langchain4j.dev/demo/openai/v1")
+//                .apiKey("demo")
+//                .organizationId(System.getenv("OPENAI_ORGANIZATION_ID"))
+//                .modelName(GPT_4_O_MINI)
+//                .logRequests(true)
+//                .logResponses(true)
+//                .build();
+//
+//        final String text = document.text();
+//        
+//        
+//        // todo - configurable, pr 
+//        //  use PromptTemplate handling via {{ }}
+//        final List<ChatMessage> messages = createUnstructuredPrompt(text/*, null, null, null, ""*/);
+//        // final PromptTemplate template = PromptTemplate.from(prompt);
+//
+//        System.out.println("messages = " + messages);
+//        // TODO -- PromptTemplate
+//
+//        //final Prompt apply = template.apply(Map.of());
+//        //final String text1 = apply.text();
+//        
+//        // TODO - DEPRECATED
+//        String rawSchema = chatModel.generate(messages)
+//                .content()
+//                .text();
+//
+//        Set<Node> nodesSet = new HashSet<>();
+//        Set<Edge> relationships = new HashSet<>();
+//
+//        List<Map<String, String>> parsedJson = parseJson(rawSchema);
+//        if (parsedJson == null) {
+//            // TODO - EVALUATE A RETRY MECHANISM CONFIGURABLE
+//            System.out.println("parsedJson = " + parsedJson);
+//            return null;
+//        }
+//
+//        for (Map<String, String> rel : parsedJson) {
+//            if (!rel.containsKey("head") || !rel.containsKey("tail") || !rel.containsKey("relation")) {
+//                continue;
+//            }
+//
+//            Node sourceNode = new Node(rel.get("head"), rel.getOrDefault("head_type", "DefaultNodeType"));
+//            Node targetNode = new Node(rel.get("tail"), rel.getOrDefault("tail_type", "DefaultNodeType"));
+//
+//            nodesSet.add(sourceNode);
+//            nodesSet.add(targetNode);
+//
+//            final String relation = rel.get("relation");
+//            final Edge edge = new Edge(sourceNode, targetNode, relation);
+//            relationships.add(edge);
+////            relationships.add(new Edge(sourceNode.getId(), targetNode.getId(), rel.get("relation")));
+//        }
+//
+////        List<Node> nodes = new ArrayList<>(nodesSet);
+//        // TODO - REMOVE THE TOSTRING()
+//        return new GraphDocument(nodesSet, relationships, document);
+////        return new GraphDocument(nodes, relationships, document);
+//    }
+//
+//    private List<Map<String, String>> parseJson(String jsonString) {
+//        ObjectMapper objectMapper = new ObjectMapper();
+//        // TODO - COMMENT THIS, can output json``` sometimes
+//        jsonString = jsonString.replaceAll("```", "")
+//                .replaceAll("json", "");
+//        try {
+//            return objectMapper.readValue(jsonString, new TypeReference<List<Map<String, String>>>() {});
+//        } catch (Exception e) {
+//            System.out.println("e = " + e);
+//            return null;
+//            // throw new RuntimeException("Error parsing JSON", e);
+//        }
+//        // Placeholder for actual JSON parsing
+//    }
+//    
+////    public List<GraphDocument> convertToGraphDocuments(List<Document> documents) {
+////        return documents.stream()
+////                .map(doc -> new GraphDocument(doc.getId(), doc.getContent()))
+////                .collect(Collectors.toList());
+////    }
+//
+//    // TODO - QUESTO IN REALTA DOVREBBE VERAMENTE GENERARE ENTITÀ
+//    //  QUINDI VA IN UNA CLASSE SEPARATA IN TEORIA...
+//    // TODO - METTERE UPPERCASE PER LE RELAZIONI, PERCHE PUO CAPITARE is_on INVECE DI IS_ON
+//    //      CAPITALIZE LABEL???
+//    public void addGraphDocuments(Graph graph, List<GraphDocument> graphDocuments, boolean includeSource, boolean baseEntityLabel) {
+//        if (baseEntityLabel && !graph.constraintExists("BaseEntity", "id")) {
+//            graph.createConstraint("BaseEntity", "id");
+//        }
+//
+//            // TODO - STA ROBA VA IN NEO4J
+////        for (GraphDocument doc : graphDocuments) {
+////            if (doc.getId() == null || doc.getId().isEmpty()) {
+////                doc.setId(generateMD5(doc.getContent()));
+////            }
+////
+////            for (Node node : doc.getNodes()) {
+////                node.setType(removeBackticks(node.getType()));
+////                graph.addNode(node);
+////            }
+////
+////            for (Edge edge : doc.getRelationships()) {
+////                edge.setSourceLabel(removeBackticks(edge.getSourceLabel()));
+////                edge.setTargetLabel(removeBackticks(edge.getTargetLabel()));
+////                edge.setType(removeBackticks(edge.getType().replace(" ", "_").toUpperCase()));
+////                graph.addEdge(edge);
+////            }
+////        }
+//    }
+//
+//    public static String generateMD5(String input) {
+//        try {
+//            MessageDigest md = MessageDigest.getInstance("MD5");
+//            md.update(input.getBytes());
+//            byte[] digest = md.digest();
+//            StringBuilder sb = new StringBuilder();
+//            for (byte b : digest) {
+//                sb.append(String.format("%02x", b));
+//            }
+//            return sb.toString();
+//        } catch (NoSuchAlgorithmException e) {
+//            throw new RuntimeException("MD5 algorithm not found", e);
+//        }
+//    }
+//
+//    public static String removeBackticks(String input) {
+//        return input.replace("`", "");
+//    }
+//}

--- a/langchain4j-neo4j/src/main/java/dev/langchain4j/transformer/LLMGraphTransformerUtils.java
+++ b/langchain4j-neo4j/src/main/java/dev/langchain4j/transformer/LLMGraphTransformerUtils.java
@@ -1,11 +1,56 @@
 package dev.langchain4j.transformer;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
 public class LLMGraphTransformerUtils {
 
+    public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    public static Map<String, Object> toMap(Object object) {
+        return OBJECT_MAPPER.convertValue(object, new TypeReference<>() {});
+    }
+
+    public static String getStringFromListOfMaps(List<Map<String, String>> examples1) {
+        try {
+            return OBJECT_MAPPER.writeValueAsString(examples1);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
+    public static  <T> T parseJson(String jsonString) throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        return objectMapper.readValue(jsonString, new TypeReference<>() {});
+    }
+    
+    public static String generateMD5(String input) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("MD5");
+            md.update(input.getBytes());
+            byte[] digest = md.digest();
+            StringBuilder sb = new StringBuilder();
+            for (byte b : digest) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("MD5 algorithm not found", e);
+        }
+    }
+
+    public static String removeBackticks(String input) {
+        return input.replace("`", "");
+    }
+    
     public static final List<Map<String, String>> EXAMPLES_PROMPT = Arrays.asList(
             Map.of(
                     "text", "Adam is a software engineer in Microsoft since 2009, and last year he got an award as the Best Talent",

--- a/langchain4j-neo4j/src/main/java/dev/langchain4j/transformer/LLMGraphTransformerUtils.java
+++ b/langchain4j-neo4j/src/main/java/dev/langchain4j/transformer/LLMGraphTransformerUtils.java
@@ -1,0 +1,51 @@
+package dev.langchain4j.transformer;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public class LLMGraphTransformerUtils {
+
+    public static final List<Map<String, String>> EXAMPLES_PROMPT = Arrays.asList(
+            Map.of(
+                    "text", "Adam is a software engineer in Microsoft since 2009, and last year he got an award as the Best Talent",
+                    "head", "Adam",
+                    "head_type", "Person",
+                    "relation", "WORKS_FOR",
+                    "tail", "Microsoft",
+                    "tail_type", "Company"
+            ),
+            Map.of(
+                    "text", "Adam is a software engineer in Microsoft since 2009, and last year he got an award as the Best Talent",
+                    "head", "Adam",
+                    "head_type", "Person",
+                    "relation", "HAS_AWARD",
+                    "tail", "Best Talent",
+                    "tail_type", "Award"
+            ),
+            Map.of(
+                    "text", "Microsoft is a tech company that provide several products such as Microsoft Word",
+                    "head", "Microsoft Word",
+                    "head_type", "Product",
+                    "relation", "PRODUCED_BY",
+                    "tail", "Microsoft",
+                    "tail_type", "Company"
+            ),
+            Map.of(
+                    "text", "Microsoft Word is a lightweight app that accessible offline",
+                    "head", "Microsoft Word",
+                    "head_type", "Product",
+                    "relation", "HAS_CHARACTERISTIC",
+                    "tail", "lightweight app",
+                    "tail_type", "Characteristic"
+            ),
+            Map.of(
+                    "text", "Microsoft Word is a lightweight app that accessible offline",
+                    "head", "Microsoft Word",
+                    "head_type", "Product",
+                    "relation", "HAS_CHARACTERISTIC",
+                    "tail", "accessible offline",
+                    "tail_type", "Characteristic"
+            )
+    );
+}

--- a/langchain4j-neo4j/src/test/java/dev/langchain4j/transformer/LLMGraphTransformerIT.java
+++ b/langchain4j-neo4j/src/test/java/dev/langchain4j/transformer/LLMGraphTransformerIT.java
@@ -1,7 +1,5 @@
 package dev.langchain4j.transformer;
 
-//import dev.langchain4j.data.document.Document;
-//import dev.langchain4j.data.document.Metadata;
 import dev.langchain4j.data.document.DefaultDocument;
 import dev.langchain4j.data.document.Document;
 import dev.langchain4j.data.document.Metadata;
@@ -9,71 +7,24 @@ import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.chat.ChatLanguageModel;
 import dev.langchain4j.model.openai.OpenAiChatModel;
-import dev.langchain4j.store.graph.neo4j.Neo4jGraph;
-import org.jetbrains.annotations.NotNull;
-import org.junit.After;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.AfterEach;
-import org.neo4j.driver.AuthTokens;
-import org.neo4j.driver.Driver;
-import org.neo4j.driver.GraphDatabase;
-import org.neo4j.driver.Record;
-import org.neo4j.driver.internal.util.Iterables;
-import org.neo4j.driver.internal.value.PathValue;
-import org.neo4j.driver.types.Node;
-import org.neo4j.driver.types.Path;
-import org.neo4j.driver.types.Relationship;
-import org.testcontainers.containers.Neo4jContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.utility.DockerImageName;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static dev.langchain4j.model.openai.OpenAiChatModelName.GPT_4_O_MINI;
-import static dev.langchain4j.store.graph.neo4j.Neo4jGraph.BASE_ENTITY_LABEL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
-// TODO - rimuovere da qui
-@Testcontainers
 class LLMGraphTransformerIT {
 
-//    OpenAiChatModel model = OpenAiChatModel.builder()
-//            .baseUrl("demo")
-//            .apiKey("demo")
-//            .organizationId(System.getenv("OPENAI_ORGANIZATION_ID"))
-//            .modelName(GPT_4_O_MINI)
-//            .logRequests(true)
-//            .logResponses(true)
-//            .build();
-
-
     private static ChatLanguageModel model;
-//    
-//    public static final String USERNAME = "neo4j";
-//    public static final String ADMIN_PASSWORD = "adminPass";
-
-    @Container
-    static Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>(DockerImageName.parse("neo4j:5.26"))
-            .withoutAuthentication()
-            .withPlugins("apoc");
-
-    private static LLMGraphTransformer graphTransformer;
-    private static Neo4jGraph graph;
-    private static Driver driver;
     
     @BeforeAll
     static void beforeAll() {
-        driver = GraphDatabase.driver(neo4jContainer.getBoltUrl(), AuthTokens.none());
-
         model = OpenAiChatModel.builder()
                 .baseUrl("http://langchain4j.dev/demo/openai/v1")
                 .apiKey("demo")
@@ -82,45 +33,7 @@ class LLMGraphTransformerIT {
                 .logRequests(true)
                 .logResponses(true)
                 .build();
-
-        // TODO - EXAMPLES WITH VARIOUS BUILDER
-        graphTransformer = LLMGraphTransformer.builder()
-                .model(model)
-                .build();
-        graph = Neo4jGraph.builder()
-                .driver(driver)
-                .build();
     }
-    
-    @BeforeEach
-    void beforeEach() {
-        // graph.e
-    }
-
-    @AfterEach
-    void afterEach() {
-        graph.executeWrite("MATCH (n) DETACH DELETE n");
-    }
-    
-    @AfterAll
-    static void afterAll() {
-        graph.close();
-    }
-
-//    @Test
-//    void testTransformGraph() {
-//        Node node = new Node("1", "Original Data");
-//        graph.addNode(node);
-//
-//        Graph transformedGraph = graphTransformer.transform(graph);
-//
-//        Assertions.assertEquals(1, transformedGraph.getNodes().size());
-//        Assertions.assertNotEquals("Original Data", transformedGraph.getNodes().get(0).getData());
-//    }
-
-
-    
-    
 
 
     @Test
@@ -137,27 +50,18 @@ class LLMGraphTransformerIT {
     void testAddGraphDocumentsWithCustomPrompt() {
         final List<ChatMessage> prompt = List.of(new UserMessage("just return a null value, don't add any explanation or extra text."));
         
-        final LLMGraphTransformer build = LLMGraphTransformer.builder()
+        final LLMGraphTransformer transformer = LLMGraphTransformer.builder()
                 .model(model)
                 .prompt(prompt)
                 .build();
 
         Document doc3 = new DefaultDocument("Keanu Reeves acted in Matrix. Keanu was born in Beirut", Metadata.from("key3", "value3"));
-        final List<GraphDocument> documents = build.convertToGraphDocuments(List.of(doc3));
+        final List<GraphDocument> documents = transformer.convertToGraphDocuments(List.of(doc3));
         assertThat(documents).isEmpty();
     }
 
     @Test
     void testAddGraphDocumentsWithCustomNodesAndRelationshipsSchema() {
-
-        Document docCat = new DefaultDocument("Sylvester the cat is on the table", Metadata.from("key2", "value2"));
-        Document docKeanu = new DefaultDocument("Keanu Reeves acted in Matrix", Metadata.from("key33", "value3"));
-        Document docLino = new DefaultDocument("Lino Banfi acted in Vieni Avanti Cretino", Metadata.from("key33", "value3"));
-        Document docGoku = new DefaultDocument("Goku acted in Dragon Ball", Metadata.from("key33", "value3"));
-        Document docHajime = new DefaultDocument("Hajime Isayama wrote Attack On Titan. Levi acted in Attack On Titan", Metadata.from("key33", "value3"));
-
-        final List<Document> docs = List.of(docCat, docKeanu, docLino, docGoku, docHajime);
-        
         String cat = "Sylvester the cat";
         String keanu = "Keanu Reeves";
         String lino = "Lino Banfi";
@@ -170,16 +74,22 @@ class LLMGraphTransformerIT {
         String db = "Dragon Ball";
         String aot = "Attack On Titan";
         
+        Document docCat = Document.from("%s is on the %s".formatted(cat, table));
+        Document docKeanu = Document.from("%s acted in %s".formatted(keanu, matrix));
+        Document docLino = Document.from("%s acted in %s".formatted(lino, vac));
+        Document docGoku = Document.from("%s acted in %s".formatted(goku, db));
+        Document docHajime = Document.from("%s wrote %s. %s acted in %s".formatted(hajime, aot, levi, aot));
+
+        final List<Document> docs = List.of(docCat, docKeanu, docLino, docGoku, docHajime);
+        
         final LLMGraphTransformer build2 = LLMGraphTransformer.builder()
                 .model(model)
                 .build();
         final List<GraphDocument> documents2 = build2.convertToGraphDocuments(docs);
-        System.out.println("documents2 = " + documents2);
-        final Stream<String> cat2 = Stream.of(cat, keanu, lino, goku, hajime, levi, table, matrix, vac, db, aot);
+        final Stream<String> expectedNodes = Stream.of(cat, keanu, lino, goku, hajime, levi, table, matrix, vac, db, aot);
         assertThat(documents2).hasSize(5);
-        extracted(documents2, cat2);
+        graphDocsAssertions(documents2, expectedNodes, Stream.of("acted", "acted", "acted", "acted", "wr.", "on"));
 
-        //assertThat(collect).isEqualTo(cat1);
 
         final LLMGraphTransformer build = LLMGraphTransformer.builder()
                 .model(model)
@@ -191,7 +101,7 @@ class LLMGraphTransformerIT {
         System.out.println("documents = " + documents);
         assertThat(documents).hasSize(4);
         final String[] strings = {keanu, lino, goku, levi, matrix, vac, db, aot};
-        extracted(documents, Stream.of(strings));
+        graphDocsAssertions(documents, Stream.of(strings), Stream.of("acted", "acted", "acted", "acted"));
         //assertThat(collect2).isEqualTo(cat12);
 
         final LLMGraphTransformer build3 = LLMGraphTransformer.builder()
@@ -206,69 +116,76 @@ class LLMGraphTransformerIT {
         assertThat(documents).hasSize(4);
         final String[] elements3 = {keanu, lino, goku, hajime, levi, matrix, vac, db, aot};
 
-        extracted(documents3, Stream.of(elements3));
-
-        //assertThat(collect2).containsExactly(keanu, lino, goku, hajime, levi, matrix, vac, db, aot);
-
-
-    }
-
-    private static void extracted(List<GraphDocument> documents3, Stream<String> expectedElements) {
-        final List<String> collect23 = getCollect(documents3);
-        final List<String> cat123 = expectedElements
-                .sorted()
-                .toList();
-        extracted(collect23, cat123);
-        
-        // TODO - relationships assertions?
-    }
-
-    // todo - rename
-    private static void extracted(List<String> collect, List<String> cat1) {
-        System.out.println("collect = " + collect);
-        assertThat(collect.size()).isEqualTo(cat1.size());
-        for (int i = 0; i < collect.size(); i++) {
-            assertThat(collect.get(i)).contains(cat1.get(i));
-        }
-    }
-
-    // todo - rename
-    private static List<String> getCollect(List<GraphDocument> documents2) {
-        return documents2.stream()
-                .flatMap(i -> i.getNodes().stream().map(GraphDocument.Node::getId))
-                .sorted()
-                .collect(Collectors.toList());
+        graphDocsAssertions(documents3, Stream.of(elements3), Stream.of("acted", "acted", "acted", "acted", "wr."));
     }
 
 
     @Test
     void testAddGraphDocumentsWithDeDuplication() {
+        final LLMGraphTransformer transformer = LLMGraphTransformer.builder()
+                .model(model)
+                .build();
+
         Document doc3 = new DefaultDocument("Keanu Reeves acted in Matrix. Keanu was born in Beirut", Metadata.from("key3", "value3"));
-        // TODO
-        // final List<Document> documents = List.of(doc2, doc3);
 
         final List<Document> documents = List.of(doc3);
-        List<GraphDocument> graphDocs = graphTransformer.convertToGraphDocuments(documents);
+        List<GraphDocument> graphDocs = transformer.convertToGraphDocuments(documents);
 
         // TODO - change assertions
         assertThat(graphDocs).hasSize(1);
-        final GraphDocument graphDocument = graphDocs.get(0);
-        final Set<GraphDocument.Edge> relationships = graphDocument.getRelationships();
-        assertThat(relationships).hasSize(2);
-        final String relStrings = relationships.stream()
-                .map(Object::toString)
-                .collect(Collectors.joining("\n"));
-        assertThat(relStrings).containsIgnoringCase("acted");
-        assertThat(relStrings).containsIgnoringCase("born");
-        
-        final Set<GraphDocument.Node> nodes = graphDocument.getNodes();
-        assertThat(nodes).hasSize(3);
-        final String nodesStrings = nodes.stream()
-                .map(Object::toString)
-                .collect(Collectors.joining("\n"));
-        assertThat(nodesStrings).containsIgnoringCase("Matrix");
-        assertThat(nodesStrings).containsIgnoringCase("Keanu");
-        assertThat(nodesStrings).containsIgnoringCase("Beirut");
+//        final GraphDocument graphDocument = graphDocs.get(0);
+//        final Document source = graphDocument.getSource();
+//        assertThat(source).isEqualTo(doc3);
+//        final Set<GraphDocument.Edge> relationships = graphDocument.getRelationships();
+//        assertThat(relationships).hasSize(2);
+//        final String relStrings = relationships.stream()
+//                .map(Object::toString)
+//                .collect(Collectors.joining("\n"));
+//        assertThat(relStrings).containsIgnoringCase("acted");
+//        assertThat(relStrings).containsIgnoringCase("born");
+//        
+//        final Set<GraphDocument.Node> nodes = graphDocument.getNodes();
+//        assertThat(nodes).hasSize(3);
+//        final String nodesStrings = nodes.stream()
+//                .map(Object::toString)
+//                .collect(Collectors.joining("\n"));
+//        assertThat(nodesStrings).containsIgnoringCase("Matrix");
+//        assertThat(nodesStrings).containsIgnoringCase("Keanu");
+//        assertThat(nodesStrings).containsIgnoringCase("Beirut");
+
+        graphDocsAssertions(graphDocs, Stream.of("matrix", "keanu", "beirut"), Stream.of("acted", "born"));
+    }
+
+    private static void graphDocsAssertions(List<GraphDocument> documents, Stream<String> expectedNodeElements, Stream<String> expectedNumRels) {
+        final List<String> actualNodes = getNodeIds(documents);
+        final List<String> actualRelationships = getRelationshipIds(documents);
+        entitiesAssertions(expectedNodeElements, actualNodes);
+
+        entitiesAssertions(expectedNumRels, actualRelationships);
+    }
+
+    private static void entitiesAssertions(Stream<String> expectedNodeElements, List<String> actualNodes) {
+        final List<String> expectedNodes = expectedNodeElements
+                .sorted()
+                .toList();
+        assertThat(actualNodes.size()).isEqualTo(expectedNodes.size());
+        for (int i = 0; i < actualNodes.size(); i++) {
+            assertThat(actualNodes.get(i).toLowerCase()).containsPattern("(?i)" + expectedNodes.get(i));
+        }
+    }
+
+    private static List<String> getNodeIds(List<GraphDocument> documents2) {
+        return documents2.stream()
+                .flatMap(i -> i.getNodes().stream().map(GraphDocument.Node::getId))
+                .sorted()
+                .collect(Collectors.toList());
+    }
+    
+    private static List<String> getRelationshipIds(List<GraphDocument> documents2) {
+        return documents2.stream()
+                .flatMap(i -> i.getRelationships().stream().map(GraphDocument.Edge::getType))
+                .sorted()
+                .collect(Collectors.toList());
     }
     
 }

--- a/langchain4j-neo4j/src/test/java/dev/langchain4j/transformer/LLMGraphTransformerIT.java
+++ b/langchain4j-neo4j/src/test/java/dev/langchain4j/transformer/LLMGraphTransformerIT.java
@@ -1,0 +1,91 @@
+package dev.langchain4j.transformer;
+
+//import dev.langchain4j.data.document.Document;
+//import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.store.graph.neo4j.Neo4jGraph;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.testcontainers.containers.Neo4jContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+
+import static dev.langchain4j.transformer.LLMGraphTransformer.*;
+
+@Testcontainers
+class LLMGraphTransformerIT {
+
+    public static final String USERNAME = "neo4j";
+    public static final String ADMIN_PASSWORD = "adminPass";
+
+    @Container
+    static Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>(DockerImageName.parse("neo4j:5.26"))
+            .withoutAuthentication()
+            .withPlugins("apoc");
+
+    private LLMGraphTransformer graphTransformer;
+    private Neo4jGraph graph;
+    private Driver driver;
+    
+    @BeforeEach
+    void setUp() {
+        driver = GraphDatabase.driver(neo4jContainer.getBoltUrl(), AuthTokens.none());
+        
+        graphTransformer = new LLMGraphTransformer(new MockLLMService());
+        graph = Neo4jGraph.builder()
+                .driver(driver)
+                .build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        graph = null;
+    }
+
+//    @Test
+//    void testTransformGraph() {
+//        Node node = new Node("1", "Original Data");
+//        graph.addNode(node);
+//
+//        Graph transformedGraph = graphTransformer.transform(graph);
+//
+//        Assertions.assertEquals(1, transformedGraph.getNodes().size());
+//        Assertions.assertNotEquals("Original Data", transformedGraph.getNodes().get(0).getData());
+//    }
+
+    @Test
+    void testAddGraphDocuments() {
+        // TODO - CHANGE DOCUMENT WITH LANGCHAIN DOCUMENT
+//        Document doc = new Document("doc1", Metadata.from("Test key", "Test content"));
+        Document doc1 = new Document("Elon Musk is suing OpenAI", Metadata.from("key1", "value1"));
+        Document doc2 = new Document("The cat is on the table", Metadata.from("key2", "value2"));
+        Document doc3 = new Document("Keanu Reeves acted in Matrix", Metadata.from("key3", "value3"));
+        final List<Document> documents = List.of(doc1, doc2, doc3);
+        List<LLMGraphTransformer.GraphDocument> graphDocs = graphTransformer.convertToGraphDocuments(documents);
+
+        graph.addGraphDocuments(graphDocs, false, false);
+        
+        
+        // TODO - ASSERTIONS 
+//        graphTransformer.addGraphDocuments(graph, graphDocs, false, false);
+
+//        Assertions.assertEquals(1, graph.getNodes().size());
+//        Assertions.assertEquals("Test content", graph.getNodes().get(0).getData());
+    }
+
+    static class MockLLMService implements LLMGraphTransformer.LLMService {
+        @Override
+        public String callLLM(String prompt) {
+            return "Transformed " + prompt;
+        }
+    }
+}

--- a/langchain4j-neo4j/src/test/java/dev/langchain4j/transformer/LLMGraphTransformerIT.java
+++ b/langchain4j-neo4j/src/test/java/dev/langchain4j/transformer/LLMGraphTransformerIT.java
@@ -2,53 +2,106 @@ package dev.langchain4j.transformer;
 
 //import dev.langchain4j.data.document.Document;
 //import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.document.DefaultDocument;
 import dev.langchain4j.data.document.Document;
 import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.openai.OpenAiChatModel;
 import dev.langchain4j.store.graph.neo4j.Neo4jGraph;
+import org.junit.After;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.neo4j.driver.AuthTokens;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.internal.util.Iterables;
+import org.neo4j.driver.internal.value.PathValue;
+import org.neo4j.driver.types.Node;
+import org.neo4j.driver.types.Path;
+import org.neo4j.driver.types.Relationship;
 import org.testcontainers.containers.Neo4jContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
-import static dev.langchain4j.transformer.LLMGraphTransformer.*;
+import static dev.langchain4j.model.openai.OpenAiChatModelName.GPT_4_O_MINI;
+import static dev.langchain4j.store.graph.neo4j.Neo4jGraph.BASE_ENTITY_LABEL;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 @Testcontainers
 class LLMGraphTransformerIT {
 
-    public static final String USERNAME = "neo4j";
-    public static final String ADMIN_PASSWORD = "adminPass";
+//    OpenAiChatModel model = OpenAiChatModel.builder()
+//            .baseUrl("demo")
+//            .apiKey("demo")
+//            .organizationId(System.getenv("OPENAI_ORGANIZATION_ID"))
+//            .modelName(GPT_4_O_MINI)
+//            .logRequests(true)
+//            .logResponses(true)
+//            .build();
+
+
+    private static ChatLanguageModel model;
+//    
+//    public static final String USERNAME = "neo4j";
+//    public static final String ADMIN_PASSWORD = "adminPass";
 
     @Container
     static Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>(DockerImageName.parse("neo4j:5.26"))
             .withoutAuthentication()
             .withPlugins("apoc");
 
-    private LLMGraphTransformer graphTransformer;
-    private Neo4jGraph graph;
-    private Driver driver;
+    private static LLMGraphTransformer graphTransformer;
+    private static Neo4jGraph graph;
+    private static Driver driver;
     
-    @BeforeEach
-    void setUp() {
+    @BeforeAll
+    static void beforeAll() {
         driver = GraphDatabase.driver(neo4jContainer.getBoltUrl(), AuthTokens.none());
-        
-        graphTransformer = new LLMGraphTransformer(new MockLLMService());
+
+        model = OpenAiChatModel.builder()
+                .baseUrl("http://langchain4j.dev/demo/openai/v1")
+                .apiKey("demo")
+                .organizationId(System.getenv("OPENAI_ORGANIZATION_ID"))
+                .modelName(GPT_4_O_MINI)
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+        // TODO - EXAMPLES WITH VARIOUS BUILDER
+        graphTransformer = LLMGraphTransformer.builder()
+                .model(model)
+                .build();
         graph = Neo4jGraph.builder()
                 .driver(driver)
                 .build();
     }
+    
+    @BeforeEach
+    void beforeEach() {
+        // graph.e
+    }
 
     @AfterEach
-    void tearDown() {
-        graph = null;
+    void afterEach() {
+        graph.executeWrite("MATCH (n) DETACH DELETE n");
+    }
+    
+    @AfterAll
+    static void afterAll() {
+        graph.close();
     }
 
 //    @Test
@@ -64,28 +117,111 @@ class LLMGraphTransformerIT {
 
     @Test
     void testAddGraphDocuments() {
-        // TODO - CHANGE DOCUMENT WITH LANGCHAIN DOCUMENT
-//        Document doc = new Document("doc1", Metadata.from("Test key", "Test content"));
-        Document doc1 = new Document("Elon Musk is suing OpenAI", Metadata.from("key1", "value1"));
-        Document doc2 = new Document("The cat is on the table", Metadata.from("key2", "value2"));
-        Document doc3 = new Document("Keanu Reeves acted in Matrix", Metadata.from("key3", "value3"));
-        final List<Document> documents = List.of(doc1, doc2, doc3);
-        List<LLMGraphTransformer.GraphDocument> graphDocs = graphTransformer.convertToGraphDocuments(documents);
+        Document doc2 = new DefaultDocument("Sylvester the cat is on the table", Metadata.from("key2", "value2"));
+        Document doc3 = new DefaultDocument("Keanu Reeves acted in Matrix", Metadata.from("key3", "value3"));
+        final List<Document> documents = List.of(doc2, doc3);
+        List<GraphDocument> graphDocs = graphTransformer.convertToGraphDocuments(documents);
 
         graph.addGraphDocuments(graphDocs, false, false);
         
-        
         // TODO - ASSERTIONS 
-//        graphTransformer.addGraphDocuments(graph, graphDocs, false, false);
+        final List<Record> records = graph.executeRead("MATCH p=()-[]->() RETURN p");
+        assertThat(records).hasSize(2);
+        records.forEach(record -> {
+            final PathValue p = (PathValue) record.get("p");
+            final Path path = p.asPath();
+            assertThat(path).hasSize(1);
+            final Node start = path.start();
+            assertThat(start.labels()).hasSize(1);
+            assertThat(start.labels()).doesNotContain(BASE_ENTITY_LABEL);
+            final Node end = path.end();
+            assertThat(end.labels()).hasSize(1);
+            assertThat(end.labels()).doesNotContain(BASE_ENTITY_LABEL);
+            final List<Relationship> rels = Iterables.asList(path.relationships());
+            assertThat(rels).hasSize(1);
+        });
+    }
+    
+    
+    @Test
+    void testAddGraphDocumentsWithBaseEntityLabel() {
+        Document docCat = new DefaultDocument("Sylvester the cat is on the table", Metadata.from("key2", "value2"));
+        Document docKeanu = new DefaultDocument("Keanu Reeves acted in Matrix", Metadata.from("key33", "value3"));
+        final List<Document> documents = List.of(docCat, docKeanu);
+        
+        // TODO - maybe metadata stored here in GraphDocument?
+        List<GraphDocument> graphDocs = graphTransformer.convertToGraphDocuments(documents);
 
-//        Assertions.assertEquals(1, graph.getNodes().size());
-//        Assertions.assertEquals("Test content", graph.getNodes().get(0).getData());
+        graph.addGraphDocuments(graphDocs, false, true);
+        
+        final List<Record> records = graph.executeRead("MATCH p=()-[]->() RETURN p");
+        assertThat(records).hasSize(2);
+        records.forEach(record -> {
+            final PathValue p = (PathValue) record.get("p");
+            final Path path = p.asPath();
+            assertThat(path).hasSize(1);
+            final Node start = path.start();
+            assertThat(start.labels()).hasSize(2);
+            assertThat(start.labels()).contains(BASE_ENTITY_LABEL);
+            final Node end = path.end();
+            assertThat(end.labels()).hasSize(2);
+            assertThat(end.labels()).contains(BASE_ENTITY_LABEL);
+            final List<Relationship> rels = Iterables.asList(path.relationships());
+            assertThat(rels).hasSize(1);
+        });
     }
 
-    static class MockLLMService implements LLMGraphTransformer.LLMService {
-        @Override
-        public String callLLM(String prompt) {
-            return "Transformed " + prompt;
+    @Test
+    void testAddGraphDocumentsWithMissingModel() {
+        try {
+            LLMGraphTransformer.builder().build();
+            fail();
+        } catch (Exception e) {
+            assertThat(e.getMessage()).contains("model cannot be null");
         }
     }
+
+    @Test
+    void testAddGraphDocumentsWithCustomPrompt() {
+        final List<ChatMessage> prompt = List.of(new UserMessage("return just a null value"));
+        
+        final LLMGraphTransformer build = LLMGraphTransformer.builder()
+                .model(model)
+                .prompt(prompt)
+                .build();
+
+        final List<GraphDocument> documents = build.convertToGraphDocuments(List.of(Document.from("foobar")));
+        System.out.println("documents = " + documents);
+    }
+
+
+    @Test
+    void testAddGraphDocumentsWithDeDuplication() {
+        Document doc3 = new DefaultDocument("Keanu Reeves acted in Matrix. Keanu was born in Beirut", Metadata.from("key3", "value3"));
+        // TODO
+        // final List<Document> documents = List.of(doc2, doc3);
+
+        final List<Document> documents = List.of(doc3);
+        List<GraphDocument> graphDocs = graphTransformer.convertToGraphDocuments(documents);
+
+        assertThat(graphDocs).hasSize(1);
+        final GraphDocument graphDocument = graphDocs.get(0);
+        final Set<GraphDocument.Edge> relationships = graphDocument.getRelationships();
+        assertThat(relationships).hasSize(2);
+        final String relStrings = relationships.stream()
+                .map(Object::toString)
+                .collect(Collectors.joining("\n"));
+        assertThat(relStrings).containsIgnoringCase("acted");
+        assertThat(relStrings).containsIgnoringCase("born");
+        
+        final Set<GraphDocument.Node> nodes = graphDocument.getNodes();
+        assertThat(nodes).hasSize(3);
+        final String nodesStrings = nodes.stream()
+                .map(Object::toString)
+                .collect(Collectors.joining("\n"));
+        assertThat(nodesStrings).containsIgnoringCase("Matrix");
+        assertThat(nodesStrings).containsIgnoringCase("Keanu");
+        assertThat(nodesStrings).containsIgnoringCase("Beirut");
+    }
+    
 }

--- a/langchain4j-neo4j/src/test/java/dev/langchain4j/transformer/Neo4jGraphTransformer.java
+++ b/langchain4j-neo4j/src/test/java/dev/langchain4j/transformer/Neo4jGraphTransformer.java
@@ -3,30 +3,207 @@ package dev.langchain4j.transformer;
 import dev.langchain4j.data.document.DefaultDocument;
 import dev.langchain4j.data.document.Document;
 import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import dev.langchain4j.store.graph.neo4j.Neo4jGraph;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.internal.util.Iterables;
+import org.neo4j.driver.internal.value.PathValue;
+import org.neo4j.driver.internal.value.StringValue;
+import org.neo4j.driver.types.Node;
+import org.neo4j.driver.types.Path;
+import org.neo4j.driver.types.Relationship;
 import org.testcontainers.containers.Neo4jContainer;
 import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
+import java.util.AbstractMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+
+import static dev.langchain4j.model.openai.OpenAiChatModelName.GPT_4_O_MINI;
+import static dev.langchain4j.store.graph.neo4j.Neo4jGraph.BASE_ENTITY_LABEL;
+import static org.assertj.core.api.Assertions.assertThat;
 
 // TODO - mettere i test con Neo4j, mentre nell'altro quelli solo di graphTransformer
 // todo - chiamarlo converter or roba del genere
+
+@Testcontainers
 public class Neo4jGraphTransformer {
+
+    private static LLMGraphTransformer graphTransformer;
+    private static List<GraphDocument> graphDocs;
+    private static Neo4jGraph graph;
+    private static Driver driver;
+    private static ChatLanguageModel model;
+    
     // TODO... 
     @Container
     static Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>(DockerImageName.parse("neo4j:5.26"))
             .withoutAuthentication()
             .withPlugins("apoc");
     
-    @BeforeEach
-    void beforeEach() {
+    @BeforeAll
+    static void beforeEach() {
+        driver = GraphDatabase.driver(neo4jContainer.getBoltUrl(), AuthTokens.none());
+
+        model = OpenAiChatModel.builder()
+                .baseUrl("http://langchain4j.dev/demo/openai/v1")
+                .apiKey("demo")
+                .organizationId(System.getenv("OPENAI_ORGANIZATION_ID"))
+                .modelName(GPT_4_O_MINI)
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+        // TODO - EXAMPLES WITH VARIOUS BUILDER
+        graphTransformer = LLMGraphTransformer.builder()
+                .model(model)
+                .build();
+        graph = Neo4jGraph.builder()
+                .driver(driver)
+                .build();
+        
+        
         Document docCat = new DefaultDocument("Sylvester the cat is on the table", Metadata.from("key2", "value2"));
         Document docKeanu = new DefaultDocument("Keanu Reeves acted in Matrix", Metadata.from("key33", "value3"));
         final List<Document> documents = List.of(docCat, docKeanu);
         // TODO -
+        graphDocs = graphTransformer.convertToGraphDocuments(documents);
+        assertThat(graphDocs.size()).isEqualTo(2);
+    }
+
+    @AfterEach
+    void afterEach() {
+        graph.executeWrite("MATCH (n) DETACH DELETE n");
+    }
+
+    @AfterAll
+    static void afterAll() {
+        graph.close();
     }
     
     // TODO - tests
+
+    @Test
+    void testAddGraphDocuments() {
+//        Document doc2 = new DefaultDocument("Sylvester the cat is on the table", Metadata.from("key2", "value2"));
+//        Document doc3 = new DefaultDocument("Keanu Reeves acted in Matrix", Metadata.from("key3", "value3"));
+//        final List<Document> documents = List.of(doc2, doc3);
+//        List<GraphDocument> graphDocs = graphTransformer.convertToGraphDocuments(documents);
+
+        graph.addGraphDocuments(graphDocs, false, false);
+
+        // TODO - ASSERTIONS 
+        final List<Record> records = graph.executeRead("MATCH p=()-[]->() RETURN p");
+        assertThat(records).hasSize(2);
+        records.forEach(record -> {
+            final PathValue p = (PathValue) record.get("p");
+            final Path path = p.asPath();
+            assertThat(path).hasSize(1);
+            final Node start = path.start();
+            assertThat(start.labels()).hasSize(1);
+            assertThat(start.labels()).doesNotContain(BASE_ENTITY_LABEL);
+            final Node end = path.end();
+            assertThat(end.labels()).hasSize(1);
+            assertThat(end.labels()).doesNotContain(BASE_ENTITY_LABEL);
+            final List<Relationship> rels = Iterables.asList(path.relationships());
+            assertThat(rels).hasSize(1);
+        });
+    }
+    
+    @Test
+    void testAddGraphDocumentsWithBaseEntityLabel() {
+//        Document docCat = new DefaultDocument("Sylvester the cat is on the table", Metadata.from("key2", "value2"));
+//        Document docKeanu = new DefaultDocument("Keanu Reeves acted in Matrix", Metadata.from("key33", "value3"));
+//        final List<Document> documents = List.of(docCat, docKeanu);
+
+        // TODO - maybe metadata stored here in GraphDocument?
+//        List<GraphDocument> graphDocs = graphTransformer.convertToGraphDocuments(documents);
+
+        graph.addGraphDocuments(graphDocs, false, true);
+
+        final List<Record> records = graph.executeRead("MATCH p=()-[]->() RETURN p");
+        assertThat(records).hasSize(2);
+        records.forEach(record -> {
+            final PathValue p = (PathValue) record.get("p");
+            final Path path = p.asPath();
+            assertThat(path).hasSize(1);
+            final Node start = path.start();
+            extracted(start);
+            final Node end = path.end();
+            extracted(end);
+            final List<Relationship> rels = Iterables.asList(path.relationships());
+            assertThat(rels).hasSize(1);
+        });
+    }
+    
+    // TODO - deignore
+    @Test
+    void testAddGraphDocumentsWithBaseEntityLabelAndIncludeSource() {
+//        Document docCat = new DefaultDocument("Sylvester the cat is on the table", Metadata.from("key2", "value2"));
+//        Document docKeanu = new DefaultDocument("Keanu Reeves acted in Matrix", Metadata.from("key33", "value3"));
+//        final List<Document> documents = List.of(docCat, docKeanu);
+
+        // TODO - maybe metadata stored here in GraphDocument?
+//        List<GraphDocument> graphDocs = graphTransformer.convertToGraphDocuments(documents);
+
+        graph.addGraphDocuments(graphDocs, true, true);
+
+        final List<Record> records = graph.executeRead("MATCH p=(:Document)-[:MENTIONS]->()-[]->() RETURN p");
+        assertThat(records).hasSize(2);
+        records.forEach(record -> {
+            final PathValue p = (PathValue) record.get("p");
+            final Path path = p.asPath();
+            assertThat(path).hasSize(2);
+            final Iterator<Node> iterator = path.nodes().iterator();
+            Node start = iterator.next();
+            assertThat(start.labels()).hasSize(1);
+            extractedDocument(start);
+
+            start = iterator.next();
+            extracted(start);
+//            final Node end = path.end();
+
+            start = iterator.next();
+            extracted(start);
+            final List<Relationship> rels = Iterables.asList(path.relationships());
+            assertThat(rels).hasSize(2);
+            assertThat(rels.get(1).type()).isNotEqualTo("MENTIONS");
+        });
+
+//        final List<Record> document = graph.executeRead("MATCH (n:Document) RETURN n");
+//        assertThat(document.size()).isEqualTo(1);
+//
+//        final NodeValue nodeValue = (NodeValue) document.get(0).get("n");
+//        final Map<String, Object> map = nodeValue.asNode().asMap();
+//        // TODO - assertions
+//        System.out.println("map = " + map);
+        
+        // TODO - additional document, check that another document is added
+        
+    }
+
+    private static void extractedDocument(Node start) {
+        assertThat(start.asMap()).containsKey("id");
+        assertThat(start.asMap()).containsKey("text");
+        assertThat(start.asMap()).containsAnyOf(
+                new AbstractMap.SimpleEntry("key2", "value2"),
+                new AbstractMap.SimpleEntry("key33", "value3")
+        );
+    }
+
+    private static void extracted(Node start) {
+        assertThat(start.labels()).hasSize(2);
+        assertThat(start.labels()).contains(BASE_ENTITY_LABEL);
+    }
 }

--- a/langchain4j-neo4j/src/test/java/dev/langchain4j/transformer/Neo4jGraphTransformer.java
+++ b/langchain4j-neo4j/src/test/java/dev/langchain4j/transformer/Neo4jGraphTransformer.java
@@ -1,0 +1,32 @@
+package dev.langchain4j.transformer;
+
+import dev.langchain4j.data.document.DefaultDocument;
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.Metadata;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.testcontainers.containers.Neo4jContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.List;
+
+// TODO - mettere i test con Neo4j, mentre nell'altro quelli solo di graphTransformer
+// todo - chiamarlo converter or roba del genere
+public class Neo4jGraphTransformer {
+    // TODO... 
+    @Container
+    static Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>(DockerImageName.parse("neo4j:5.26"))
+            .withoutAuthentication()
+            .withPlugins("apoc");
+    
+    @BeforeEach
+    void beforeEach() {
+        Document docCat = new DefaultDocument("Sylvester the cat is on the table", Metadata.from("key2", "value2"));
+        Document docKeanu = new DefaultDocument("Keanu Reeves acted in Matrix", Metadata.from("key33", "value3"));
+        final List<Document> documents = List.of(docCat, docKeanu);
+        // TODO -
+    }
+    
+    // TODO - tests
+}

--- a/langchain4j-neo4j/src/test/java/dev/langchain4j/transformer/Neo4jGraphTransformer.java
+++ b/langchain4j-neo4j/src/test/java/dev/langchain4j/transformer/Neo4jGraphTransformer.java
@@ -40,6 +40,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Testcontainers
 public class Neo4jGraphTransformer {
 
+    public static final String SYLVESTER_THE_CAT_IS_ON_THE_TABLE = "Sylvester the cat is on the table";
+    public static final String KEANU_REEVES_ACTED_IN_MATRIX = "Keanu Reeves acted in Matrix";
     private static LLMGraphTransformer graphTransformer;
     private static List<GraphDocument> graphDocs;
     private static Neo4jGraph graph;
@@ -74,10 +76,10 @@ public class Neo4jGraphTransformer {
                 .build();
         
         
-        Document docCat = new DefaultDocument("Sylvester the cat is on the table", Metadata.from("key2", "value2"));
-        Document docKeanu = new DefaultDocument("Keanu Reeves acted in Matrix", Metadata.from("key33", "value3"));
+        Document docCat = new DefaultDocument(SYLVESTER_THE_CAT_IS_ON_THE_TABLE, Metadata.from("key2", "value2"));
+        Document docKeanu = new DefaultDocument(KEANU_REEVES_ACTED_IN_MATRIX, Metadata.from("key33", "value3"));
         final List<Document> documents = List.of(docCat, docKeanu);
-        // TODO -
+        // TODO - retry util??
         graphDocs = graphTransformer.convertToGraphDocuments(documents);
         assertThat(graphDocs.size()).isEqualTo(2);
     }
@@ -194,12 +196,21 @@ public class Neo4jGraphTransformer {
     }
 
     private static void extractedDocument(Node start) {
-        assertThat(start.asMap()).containsKey("id");
-        assertThat(start.asMap()).containsKey("text");
-        assertThat(start.asMap()).containsAnyOf(
-                new AbstractMap.SimpleEntry("key2", "value2"),
-                new AbstractMap.SimpleEntry("key33", "value3")
-        );
+        final Map<String, Object> map = start.asMap();
+        assertThat(map).containsKey("id");
+        final Object text = map.get("text");
+        if (text.equals(SYLVESTER_THE_CAT_IS_ON_THE_TABLE)) {
+            assertThat(map.get("key2")).isEqualTo("value2");
+        } else if (text.equals(KEANU_REEVES_ACTED_IN_MATRIX)){
+            assertThat(map.get("key33")).isEqualTo("value3");
+        } else {
+            throw new RuntimeException("TODO");
+        }
+//        assertThat(map).containsKey("text");
+//        assertThat(map).containsAnyOf(
+//                new AbstractMap.SimpleEntry("key2", "value2"),
+//                new AbstractMap.SimpleEntry("key33", "value3")
+//        );
     }
 
     private static void extracted(Node start) {

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiChatModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiChatModel.java
@@ -64,13 +64,13 @@ public class OpenAiChatModel implements ChatLanguageModel, TokenCountEstimator {
 
     public OpenAiChatModel(OpenAiChatModelBuilder builder) {
 
-        if ("demo".equals(builder.apiKey)) {
-            // TODO remove before releasing 1.0.0
-            throw new RuntimeException("""
-                    If you wish to continue using the 'demo' key, please specify the base URL explicitly:
-                    OpenAiChatModel.builder().baseUrl("http://langchain4j.dev/demo/openai/v1").apiKey("demo").build();
-                    """);
-        }
+//        if ("demo".equals(builder.apiKey)) {
+//            // TODO remove before releasing 1.0.0
+//            throw new RuntimeException("""
+//                    If you wish to continue using the 'demo' key, please specify the base URL explicitly:
+//                    OpenAiChatModel.builder().baseUrl("http://langchain4j.dev/demo/openai/v1").apiKey("demo").build();
+//                    """);
+//        }
 
         this.client = OpenAiClient.builder()
                 .httpClientBuilder(builder.httpClientBuilder)


### PR DESCRIPTION
TODO - valutare differenze con python:
- [ ] si può fare a meno delle apoc?

---

Issue 2543


- Option to link entities back to the source document
- These knowledge graphs form the foundation for advanced RAG patterns in GraphRAG (see https://graphrag.com)
- Besides data from document loaders also data that already exists in large text fields in databases (semi-structured data) could be analyzed and extracted
This also offers the means to then run additional algorithms on the data e.g. for query focused summarization that compute communities/clusters of topics and summarize them with an LLM


The baseEntityLabel parameter assigns an additional __Entity__ label to each node, 
enhancing indexing and query performance.

The include_source parameter links nodes to their originating documents, 
facilitating data traceability and context understanding.



EVALUATE: failsSilently, return null...


EVALUATE: String rawSchema = model.generate(messages) is deprecate, how to change it??


TODO Entity de-duplication with the LLM and possibly other methods (slightly different spelling of names/ids)

--- 

    A general concept of NER / Entity / Relationship extraction
    Then processing / storing these entities in databases .e.g graph databases like neo4j (but relational would work as well)
    TODO - done via allowedNodes, allowedRelationships, Options for providing graph schema and additional extraction for the construction