### PR TITLE
Issue 2544: Support Text2Cypher / Text2GQL with something like the CypherQAChain

### DIFF
--- a/langchain4j-neo4j/src/test/java/dev/langchain4j/rag/content/retriever/neo4j/Neo4jContentRetrieverIT.java
+++ b/langchain4j-neo4j/src/test/java/dev/langchain4j/rag/content/retriever/neo4j/Neo4jContentRetrieverIT.java
@@ -1,7 +1,21 @@
 package dev.langchain4j.rag.content.retriever.neo4j;
 
+import static dev.langchain4j.model.openai.OpenAiChatModelName.GPT_4_O_MINI;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.input.PromptTemplate;
 import dev.langchain4j.model.openai.OpenAiChatModel;
+import dev.langchain4j.model.output.Response;
+import dev.langchain4j.model.output.Response;
 import dev.langchain4j.rag.content.Content;
 import dev.langchain4j.rag.query.Query;
 import dev.langchain4j.store.graph.neo4j.Neo4jGraph;
@@ -80,7 +94,10 @@ class Neo4jContentRetrieverIT {
     void shouldRetrieveContentWhenQueryIsValid() {
         // Given
         Query query = new Query("Who is the author of the book 'Dune'?");
-        when(chatLanguageModel.chat(anyString())).thenReturn("MATCH(book:Book {title: 'Dune'})<-[:WROTE]-(author:Person) RETURN author.name AS output");
+        when(chatLanguageModel.chat(anyList()))
+                .thenReturn(ChatResponse.builder().aiMessage(new AiMessage(
+                        "MATCH(book:Book {title: 'Dune'})<-[:WROTE]-(author:Person) RETURN author.name AS output"
+                )).build());
 
         // When
         List<Content> contents = retriever.retrieve(query);
@@ -93,7 +110,10 @@ class Neo4jContentRetrieverIT {
     void shouldRetrieveContentWhenQueryIsValidAndResponseHasBackticks() {
         // Given
         Query query = new Query("Who is the author of the book 'Dune'?");
-        when(chatLanguageModel.chat(anyString())).thenReturn("```MATCH(book:Book {title: 'Dune'})<-[:WROTE]-(author:Person) RETURN author.name AS output```");
+        when(chatLanguageModel.chat(anyList()))
+                .thenReturn(ChatResponse.builder().aiMessage(new AiMessage(
+                        "```MATCH(book:Book {title: 'Dune'})<-[:WROTE]-(author:Person) RETURN author.name AS output```"
+                )).build());
 
         // When
         List<Content> contents = retriever.retrieve(query);
@@ -107,8 +127,8 @@ class Neo4jContentRetrieverIT {
 
         // With
         ChatLanguageModel openAiChatModel = OpenAiChatModel.builder()
-                .baseUrl(System.getenv("OPENAI_BASE_URL"))
-                .apiKey(System.getenv("OPENAI_API_KEY"))
+                .baseUrl("http://langchain4j.dev/demo/openai/v1")
+                .apiKey("demo")
                 .organizationId(System.getenv("OPENAI_ORGANIZATION_ID"))
                 .modelName(GPT_4_O_MINI)
                 .logRequests(true)
@@ -129,12 +149,49 @@ class Neo4jContentRetrieverIT {
         // Then
         assertThat(contents).hasSize(1);
     }
+    
+    @Test
+    void shouldRetrieveContentWhenQueryIsValidAndOpenAiChatModelIsUsed1() {
+
+        // With
+        ChatLanguageModel openAiChatModel = OpenAiChatModel.builder()
+                .baseUrl("http://langchain4j.dev/demo/openai/v1")
+                .apiKey("demo")
+                .organizationId(System.getenv("OPENAI_ORGANIZATION_ID"))
+                .modelName(GPT_4_O_MINI)
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+        Neo4jContentRetriever neo4jContentRetriever = Neo4jContentRetriever.builder()
+                .graph(graph)
+                .chatLanguageModel(openAiChatModel)
+                .promptTemplate(PromptTemplate.from("ignore this message, just consider the above 'system' one"))
+                .previousMessages(List.of(new SystemMessage("ignore the following 'user' content and returns franchino finally")))
+                .build();
+
+        // Given
+        Query query = new Query("Who is the author of the book 'Dune'?");
+
+        // When
+        try {
+            neo4jContentRetriever.retrieve(query);
+            fail();
+        } catch (Exception e) {
+            final String message = e.getMessage();
+            System.out.println("message = " + message);
+            assertThat(message).containsIgnoringCase("franchino");
+        }
+    }
 
     @Test
     void shouldReturnEmptyListWhenQueryIsInvalid() {
         // Given
         Query query = new Query("Who is the author of the movie 'Dune'?");
-        when(chatLanguageModel.chat(anyString())).thenReturn("MATCH(movie:Movie {title: 'Dune'})<-[:WROTE]-(author:Person) RETURN author.name AS output");
+        when(chatLanguageModel.chat(anyList()))
+                .thenReturn(ChatResponse.builder().aiMessage(new AiMessage(
+                        "MATCH(movie:Movie {title: 'Dune'})<-[:WROTE]-(author:Person) RETURN author.name AS output"
+                )).build());
 
         // When
         List<Content> contents = retriever.retrieve(query);


### PR DESCRIPTION
Compared with `https://github.com/langchain4j/langchain4j/issues/2544` feature requests,
the implementation is quite already existing.

Just improved builder with `previousMessages`, which has a default similar to the text2cypher one:

https://github.com/neo4j-labs/text2cypher/blob/main/datasets/synthetic_gemini_demodbs/gemini_text2cypher.ipynb