### PR TITLE
Fixes 2705: [BUG] Neo4j EmbeddingStore fails to build if NODE_KEY constraint exist

### DIFF
--- a/langchain4j-neo4j/src/main/java/dev/langchain4j/store/embedding/neo4j/Neo4jEmbeddingStore.java
+++ b/langchain4j-neo4j/src/main/java/dev/langchain4j/store/embedding/neo4j/Neo4jEmbeddingStore.java
@@ -248,6 +248,13 @@ public class Neo4jEmbeddingStore implements EmbeddingStore<TextSegment> {
 
     private void createUniqueConstraint() {
         try (var session = session()) {
+            // check if an equivalent constraint exists 
+            var resConstraint = session.run("SHOW CONSTRAINT WHERE labelsOrTypes = [$label] AND properties = [$idProperty]", 
+                    Map.of("label", this.label, "idProperty", this.idProperty));
+            if (resConstraint.hasNext()) {
+                return;
+            }
+            
             String query = String.format(
                     "CREATE CONSTRAINT IF NOT EXISTS FOR (n:%s) REQUIRE n.%s IS UNIQUE",
                     this.sanitizedLabel,


### PR DESCRIPTION
Fixes `https://github.com/langchain4j/langchain4j/issues/2705`

With NODE_KEY, the `CREATE CONSTRAINT IF NOT EXISTS`  doesn't work,
so we have to check for it manually via `SHOW CONSTRAINT WHERE labelsOrTypes = [$label] AND properties = [$idProperty]`.

Changed the neo4j container to enterprise since the NODE KEY constraint is available only with enterprise edition